### PR TITLE
LDAP sync, 1st working draft

### DIFF
--- a/ckanext/georchestra/__init__.py
+++ b/ckanext/georchestra/__init__.py
@@ -1,0 +1,7 @@
+# this is a namespace package
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/ckanext/georchestra/commands/__init__.py
+++ b/ckanext/georchestra/commands/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+Created by 'bens3' on 2013-06-21.
+Copyright (c) 2013 'bens3'. All rights reserved.
+"""
+
+import sys
+import os
+
+
+def main():
+    pass
+
+
+if __name__ == '__main__':
+    main()

--- a/ckanext/georchestra/commands/georchestra_ldap.py
+++ b/ckanext/georchestra/commands/georchestra_ldap.py
@@ -1,0 +1,252 @@
+import logging
+import pylons
+from ckan.lib.cli import CkanCommand
+from ckan.plugins import toolkit
+from ckan import logic
+from logic import ValidationError
+import ldap, ldap.filter
+from ckan.common import config
+import dateutil
+
+
+log = logging.getLogger()
+
+
+class GeorchestraLDAPCommand(CkanCommand):
+    """
+    Paster function to synchronize the users/organizations with the LDAP directory
+    Commands:
+        paster georchestra ldap-sync-all -c /etc/ckan/default/development.ini
+    """
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+
+    cnx = None
+    ldap_orgs_list = None
+
+    def command(self):
+
+        if not self.args or self.args[0] in ['--help', '-h', 'help']:
+            print self.__doc__
+            return
+
+        self._load_config()
+
+        # Set up context
+        user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
+        self.context = {'user': user['name']}
+
+        cmd = self.args[0]
+
+        if cmd == 'ldap_sync_all':
+            self.ldap_sync_all()
+        else:
+            print 'Command %s not recognized' % cmd
+
+    def ldap_sync_all(self):
+
+        log.setLevel(logging.DEBUG)
+        # Get the organisation all users will be added to
+        #organization_id = pylons.config['ckanext.georchestra.ldap.organization.id']
+        #
+        #try:
+        #    toolkit.get_action('organization_show')(self.context, {'id': organization_id})
+        #except logic.NotFound:
+        #    toolkit.get_action('organization_create')(self.context, {'id': organization_id, 'name': organization_id})
+        self.sync_organizations()
+        pass
+
+    def preseed(self):
+        """
+        Clean the ckan instance
+        create some common orgs, some deprecated ones and leave some uncreated
+        :return:
+        """
+        self.organization_create({'id':'fake', 'name':'fake'})
+        for org in ['psc', 'c2c', 'cra']:
+            try:
+                toolkit.get_action('organization_purge')(self.context, {'id': org})
+                log.debug("purged organization {0}".format(org))
+                org = toolkit.get_action('organization_show')(self.context, {'id': org})
+                log.debug("organization {0} already exists".format(org))
+            except logic.NotFound:
+                # Means the organization was not found => we create it
+                if org in ['c2c','psc']:
+                    self.organization_create({'id':org, 'name':org})
+
+    def sync_organizations(self):
+        self.preseed()
+        ldap_orgs_list = self.get_ldap_orgs()
+        ckan_orgs_names_list = self.get_ckan_orgs()
+
+        ckan_orgs_set=set(ckan_orgs_names_list)
+
+        orgs_exist = [ el for el in ldap_orgs_list if el['id'] in ckan_orgs_set ]
+        orgs_missing = [ el for el in ldap_orgs_list if el['id'] not in ckan_orgs_set ]
+        orgs_deprecated = list( ckan_orgs_set - set([el['id'] for el in ldap_orgs_list]))
+
+        self.organizations_update(orgs_exist)
+        self.organizations_add(orgs_missing)
+        self.organizations_remove(orgs_deprecated)
+
+        log.debug("ok !")
+
+    def get_ldap_connection(self):
+        """
+        Use this function to get the LDA connection: this way, you ensure it will always be initialized
+        :return: LDAP connection object
+        """
+        # TODO manage bytes_mode=False : see how to properly deal with unicode config. I can unicode(config[...]) every
+        #      config file, but this looks dirty
+        # TODO trace_level seems not possible to configure from ini files. Strange
+        if self.cnx != None:
+            return self.cnx
+
+        cnx = ldap.initialize(config['ckanext.georchestra.ldap.uri'], bytes_mode=True, trace_level=2)
+
+        if config.get('ckanext.georchestra.ldap.auth.dn'):
+            try:
+                if config['ckanext.georchestra.ldap.auth.method'] == 'SIMPLE':
+                    cnx.bind_s(config['ckanext.georchestra.ldap.auth.dn'],
+                               config['ckanext.georchestra.ldap.auth.password'])
+                elif config['ckanext.georchestra.ldap.auth.method'] == 'SASL':
+                    if config['ckanext.georchestra.ldap.auth.mechanism'] == 'DIGEST-MD5':
+                        auth_tokens = ldap.sasl.digest_md5(config['ckanext.georchestra.ldap.auth.dn'],
+                                                           config['ckanext.georchestra.ldap.auth.password'])
+                        cnx.sasl_interactive_bind_s("", auth_tokens)
+                    else:
+                        log.error("SASL mechanism not supported: {0}".format(
+                            config['ckanext.georchestra.ldap.auth.mechanism']))
+                        return None
+                else:
+                    log.error(
+                        "LDAP authentication method is not supported: {0}".format(
+                            config['ckanext.georchestra.ldap.auth.method']))
+                    return None
+            except ldap.SERVER_DOWN:
+                log.error('LDAP server is not reachable')
+                return None
+            except ldap.INVALID_CREDENTIALS:
+                log.error(
+                    'LDAP server credentials (ckanext.georchestra.ldap.auth.dn and ckanext.georchestra.ldap.auth.password) invalid')
+                return None
+            except ldap.LDAPError, e:
+                log.error("Fatal LDAP Error: {0}".format(e))
+                return None
+        self.cnx=cnx
+        return cnx
+
+    def get_ldap_orgs(self):
+        """
+        Get LDAP organization list
+        :return:
+        """
+        if self.ldap_orgs_list != None:
+            return self.ldap_orgs_list
+
+        cnx= self.get_ldap_connection()
+        ldap_search_result = cnx.search_s(config['ckanext.georchestra.ldap.base_dn.orgs'], ldap.SCOPE_ONELEVEL,
+                                          filterstr='(objectClass=groupOfMembers)',
+                                          attrlist=['cn', 'o', 'seeAlso', 'modifytimestamp'])
+        ldap_orgs_list = []
+        for elt in ldap_search_result:
+            ts=elt[1]['modifyTimestamp'][0]
+            log.debug("timestamp {0}".format(ts.decode('utf8')))
+            org = { 'name' : elt[1]['cn'][0].decode('utf_8'),
+                    'id' : elt[1]['cn'][0].decode('utf_8'),
+                    'title' : elt[1]['o'][0].decode('utf_8'),
+                    'update_ts' : dateutil.parser.parse(elt[1]['modifyTimestamp'][0].decode('utf_8'))
+                    }
+            see_also_links = elt[1]['seeAlso']
+            for link in see_also_links:
+                res = cnx.search_s(link, ldap.SCOPE_BASE,
+                                                  filterstr='(objectClass=*)', attrlist=None)
+                if res[0][0].startswith('o='):
+                    org['description'] = res[0][1]['description'][0]
+                else:
+                    #org['image_url'] =  res[0][1]['jpegPhoto'][0]
+                    pass
+            ldap_orgs_list.append(org)
+
+        self.ldap_orgs_list = ldap_orgs_list
+        return ldap_orgs_list
+
+    def get_ldap_orgs_list(self):
+        ldap_orgs = self.get_ldap_orgs()
+        ldap_orgs_list = []
+        for item in ldap_orgs:
+            ldap_orgs_list.append(item['id'])
+        return ldap_orgs_list
+
+    def get_ckan_orgs(self):
+        orgs = toolkit.get_action('organization_list')(self.context, {'limit': 1000, 'all_fields':False})
+        return orgs
+
+    def organizations_update(self, orgs_list):
+        for org in orgs_list:
+            try:
+                #current_org = toolkit.get_action('organization_show')(self.context, {'id': org['id'], 'include_extras':True})
+                revisions = toolkit.get_action('organization_revision_list')(self.context,
+                                                                      {'id': org['id']})
+                # in order to be able to compare with LDAP timestamp, we need it to be seen as time-aware.
+                # TODO: check it is really UTC time always
+                #last_revision=dateutil.parser.parse(revisions[0]['timestamp']+'Z')
+                last_revision = dateutil.parser.parse('20190208085726Z')
+                if org['update_ts'] > last_revision:
+                    # then we update it
+                    log.debug("updating organization {0}".format(org['id']))
+                    current_org = toolkit.get_action('organization_patch')(self.context,
+                                                                          org)
+                log.debug("ok")
+            except:
+                log.error("Could not read organization {0} (should exist though".format(org))
+
+    def organizations_add(self, orgs_list):
+        # trick to solve this SQLalchemy flushing issue. It seems 'group' info stays present in the self.session and
+        # messes things up. Clearing the 'group' var seems to help.
+        self.context['group'] = None
+        for org in orgs_list:
+            self.organization_create(org)
+            log.debug("added organization {0}".format(org['id']))
+
+    def organizations_remove(self, orgs_list):
+        # TODO : check content and move all packages to a 'ghost' org before purging org
+        for org in orgs_list:
+            try:
+                toolkit.get_action('organization_purge')(self.context, {'id': org})
+                log.debug("purged organization {0}".format(org))
+            except:
+                log.error("could not purge organization {0}".format(org))
+
+    def organization_create(self, data_dict):
+        # Apply auth fix from https://github.com/datagovuk/ckanext-harvest/commit/f315f41c86cbde4a49ef869b6993598f8cb11e2d
+        # to error message Action function organization_show did not call its auth function
+        self.context.pop('__auth_audit', None)
+        try:
+            log.debug("creating organization {0}".format(data_dict['id']))
+            toolkit.get_action('organization_create')(self.context, data_dict)
+        except ValidationError, e:
+            log.error(e['name'])
+
+    def organization_delete(self, id):
+        # TODO : resolve bug, see comment underneath
+        """
+        Don't use it. It generates an error from sqlalchemy :
+        related attribute set' operation is not currently supported within the execution stage of the flush process
+        already reported and closed (https://github.com/ckan/ckan/issues/2017). See if I can identify it or propose a
+        reliable way to reproduce ut (seems pretty reliable right now : just run twice organization_delete then some
+        organization_create and it all goes weird. For instance, my preseed function was like this :
+        for org in ['psc', 'c2c', 'cra', 'fake']:
+            self.organization_delete(org)
+
+        self.organization_create("c2c", None))
+        self.organization_create("fake", None)
+        and it would not create c2c organization, after issuing the sqlalchemy error)
+        """
+        self.context.pop('__auth_audit', None)
+        try:
+            toolkit.get_action('organization_purge')(self.context, {'id': id})
+            log.debug("purged organization {0}".format(id))
+        except:
+            log.error("could not delete org {0}".format(id))
+

--- a/ckanext/georchestra/commands/georchestra_ldap.py
+++ b/ckanext/georchestra/commands/georchestra_ldap.py
@@ -106,6 +106,9 @@ class GeorchestraLDAPCommand(CkanCommand):
                 except toolkit.ObjectNotFound:
                     user_utils.create(self.context, user, org)
                 processed_userids.append(user['id'])
+                #Hack to prevent errors in next action('user_show'):
+                self.context['user_obj']=None
+                self.context['with_capacity']=False
         ckan_all_users = toolkit.get_action('user_list')(self.context, {'all_fields':False})
         orphan_users = set(ckan_all_users)-set(processed_userids)
         log.debug("there are {0} orphan users to remove".format(len(orphan_users)))

--- a/ckanext/georchestra/commands/georchestra_ldap.py
+++ b/ckanext/georchestra/commands/georchestra_ldap.py
@@ -1,11 +1,11 @@
 import logging
 import dateutil
 
-import ldap, ldap.filter
 from ckan.lib.cli import CkanCommand
 from ckan.plugins import toolkit
 from ckan.plugins.toolkit import config
 
+from ckanext.georchestra.commands.utils import ldap_utils
 from ckanext.georchestra.commands.utils import organizations
 
 
@@ -44,21 +44,15 @@ class GeorchestraLDAPCommand(CkanCommand):
             print 'Command %s not recognized' % cmd
 
     def ldap_sync_all(self):
-
         log.setLevel(logging.DEBUG)
-        # Get the organisation all users will be added to
-        #organization_id = pylons.config['ckanext.georchestra.ldap.organization.id']
-        #
-        #try:
-        #    toolkit.get_action('organization_show')(self.context, {'id': organization_id})
-        #except logic.NotFound:
-        #    toolkit.get_action('organization_create')(self.context, {'id': organization_id, 'name': organization_id})
-        self.sync_organizations()
-        pass
+        
+        ldap_cnx= ldap_utils.get_ldap_connection()
+        self.sync_organizations(ldap_cnx)
 
-    def sync_organizations(self):
+
+    def sync_organizations(self, ldap_cnx):
         organizations.preseed(self.context)
-        ldap_orgs_list = self.get_ldap_orgs()
+        ldap_orgs_list = ldap_utils.get_ldap_orgs(ldap_cnx)
         ckan_orgs_names_list = self.get_ckan_orgs()
 
         ckan_orgs_set=set(ckan_orgs_names_list)
@@ -71,94 +65,7 @@ class GeorchestraLDAPCommand(CkanCommand):
         organizations.add(self.context,orgs_missing)
         organizations.remove(self.context,orgs_deprecated)
 
-        log.debug("ok !")
-
-    def get_ldap_connection(self):
-        """
-        Use this function to get the LDA connection: this way, you ensure it will always be initialized
-        :return: LDAP connection object
-        """
-        # TODO manage bytes_mode=False : see how to properly deal with unicode config. I can unicode(config[...]) every
-        #      config file, but this looks dirty
-        # TODO trace_level seems not possible to configure from ini files. Strange
-        if self.cnx != None:
-            return self.cnx
-
-        cnx = ldap.initialize(config['ckanext.georchestra.ldap.uri'], bytes_mode=True, trace_level=2)
-
-        if config.get('ckanext.georchestra.ldap.auth.dn'):
-            try:
-                if config['ckanext.georchestra.ldap.auth.method'] == 'SIMPLE':
-                    cnx.bind_s(config['ckanext.georchestra.ldap.auth.dn'],
-                               config['ckanext.georchestra.ldap.auth.password'])
-                elif config['ckanext.georchestra.ldap.auth.method'] == 'SASL':
-                    if config['ckanext.georchestra.ldap.auth.mechanism'] == 'DIGEST-MD5':
-                        auth_tokens = ldap.sasl.digest_md5(config['ckanext.georchestra.ldap.auth.dn'],
-                                                           config['ckanext.georchestra.ldap.auth.password'])
-                        cnx.sasl_interactive_bind_s("", auth_tokens)
-                    else:
-                        log.error("SASL mechanism not supported: {0}".format(
-                            config['ckanext.georchestra.ldap.auth.mechanism']))
-                        return None
-                else:
-                    log.error(
-                        "LDAP authentication method is not supported: {0}".format(
-                            config['ckanext.georchestra.ldap.auth.method']))
-                    return None
-            except ldap.SERVER_DOWN:
-                log.error('LDAP server is not reachable')
-                return None
-            except ldap.INVALID_CREDENTIALS:
-                log.error(
-                    'LDAP server credentials (ckanext.georchestra.ldap.auth.dn and ckanext.georchestra.ldap.auth.password) invalid')
-                return None
-            except ldap.LDAPError, e:
-                log.error("Fatal LDAP Error: {0}".format(e))
-                return None
-        self.cnx=cnx
-        return cnx
-
-    def get_ldap_orgs(self):
-        """
-        Get LDAP organization list
-        :return:
-        """
-        if self.ldap_orgs_list != None:
-            return self.ldap_orgs_list
-
-        cnx= self.get_ldap_connection()
-        ldap_search_result = cnx.search_s(config['ckanext.georchestra.ldap.base_dn.orgs'], ldap.SCOPE_ONELEVEL,
-                                          filterstr='(objectClass=groupOfMembers)',
-                                          attrlist=['cn', 'o', 'seeAlso', 'modifytimestamp'])
-        ldap_orgs_list = []
-        for elt in ldap_search_result:
-            ts=elt[1]['modifyTimestamp'][0]
-            log.debug("timestamp {0}".format(ts.decode('utf8')))
-            org = { 'name' : elt[1]['cn'][0].decode('utf_8'),
-                    'id' : elt[1]['cn'][0].decode('utf_8'),
-                    'title' : elt[1]['o'][0].decode('utf_8'),
-                    'update_ts' : dateutil.parser.parse(elt[1]['modifyTimestamp'][0].decode('utf_8'))
-                    }
-            see_also_links = elt[1]['seeAlso']
-            for link in see_also_links:
-                res = cnx.search_s(link, ldap.SCOPE_BASE,
-                                                  filterstr='(objectClass=*)', attrlist=None)
-                if res[0][0].startswith('o='):
-                    org['description'] = res[0][1]['description'][0]
-                else:
-                    #org['image_url'] =  res[0][1]['jpegPhoto'][0]
-                    pass
-            ldap_orgs_list.append(org)
-
-        self.ldap_orgs_list = ldap_orgs_list
-        return ldap_orgs_list
-
-    def get_ldap_orgs_list(self):
-        ldap_orgs = self.get_ldap_orgs()
-        ldap_orgs_list = []
-        for item in ldap_orgs:
-            ldap_orgs_list.append(item['id'])
-        return ldap_orgs_list
+        log.debug("orgs sync ok !")
 
     def get_ckan_orgs(self):
         orgs = toolkit.get_action('organization_list')(self.context, {'limit': 1000, 'all_fields':False})

--- a/ckanext/georchestra/commands/georchestra_ldap.py
+++ b/ckanext/georchestra/commands/georchestra_ldap.py
@@ -93,19 +93,19 @@ class GeorchestraLDAPCommand(CkanCommand):
         # keep root sysadmin users (like the one running this current command) out of the sync process (we don't want
         # them removed...)
         processed_userids = config['ckanext.georchestra.external_users'].split(",")
-        for org in ldap_orgs_list:
-            ldap_users_list = ldap_utils.get_ldap_org_members(ldap_cnx, org, roles)
+        for ldap_org in ldap_orgs_list:
+            ldap_users_list = ldap_utils.get_ldap_org_members(ldap_cnx, ldap_org, roles)
             #TODO: see if we shouldn't use instead toolkit.get_action('organization_list')(self.context, {'limit': 1000, 'all_fields':True, 'include_users':True, 'organizations':[org['id']]})
             #to get a list of the users with capacity information
-            for user in  ldap_users_list:
+            for ldap_user in  ldap_users_list:
                 try:
-                    log.debug("checking user {0}".format(user['id']))
-                    u = toolkit.get_action('user_show')(self.context, {'id':user['id']})
+                    log.debug("checking user {0}".format(ldap_user['id']))
+                    ckan_user = toolkit.get_action('user_show')(self.context, {'id':ldap_user['id']})
                     # no exception means the user already exists in the DB
-                    user_utils.update(self.context, user, u, org)
+                    user_utils.update(self.context, ldap_user, ckan_user, ldap_org)
                 except toolkit.ObjectNotFound:
-                    user_utils.create(self.context, user, org)
-                processed_userids.append(user['id'])
+                    user_utils.create(self.context, ldap_user, ldap_org)
+                processed_userids.append(ldap_user['id'])
                 #Hack to prevent errors in next action('user_show'):
                 self.context['user_obj']=None
                 self.context['with_capacity']=False

--- a/ckanext/georchestra/commands/georchestra_ldap.py
+++ b/ckanext/georchestra/commands/georchestra_ldap.py
@@ -6,7 +6,8 @@ from ckan.plugins import toolkit
 from ckan.plugins.toolkit import config
 
 from ckanext.georchestra.commands.utils import ldap_utils
-from ckanext.georchestra.commands.utils import organizations
+from ckanext.georchestra.commands.utils import organizations as org_utils
+from ckanext.georchestra.commands.utils import users as user_utils
 
 
 log = logging.getLogger()
@@ -23,6 +24,10 @@ class GeorchestraLDAPCommand(CkanCommand):
 
     cnx = None
     ldap_orgs_list = None
+
+    #TODO: change those values to False for prod
+    is_dev_mode=True
+    is_debug_mode=True
 
     def command(self):
 
@@ -45,13 +50,14 @@ class GeorchestraLDAPCommand(CkanCommand):
 
     def ldap_sync_all(self):
         log.setLevel(logging.DEBUG)
-        
+
         ldap_cnx= ldap_utils.get_ldap_connection()
-        self.sync_organizations(ldap_cnx)
+        ldap_orgs_list = self.sync_organizations(ldap_cnx)
+        self.sync_users(ldap_cnx, ldap_orgs_list)
 
 
     def sync_organizations(self, ldap_cnx):
-        organizations.preseed(self.context)
+        org_utils.preseed(self.context)
         ldap_orgs_list = ldap_utils.get_ldap_orgs(ldap_cnx)
         ckan_orgs_names_list = self.get_ckan_orgs()
 
@@ -61,12 +67,49 @@ class GeorchestraLDAPCommand(CkanCommand):
         orgs_missing = [ el for el in ldap_orgs_list if el['id'] not in ckan_orgs_set ]
         orgs_deprecated = list( ckan_orgs_set - set([el['id'] for el in ldap_orgs_list]))
 
-        organizations.update(self.context,orgs_exist)
-        organizations.add(self.context,orgs_missing)
-        organizations.remove(self.context,orgs_deprecated)
+        org_utils.update(self.context,orgs_exist, force_update=self.is_dev_mode)
+        org_utils.add(self.context,orgs_missing)
+        org_utils.remove(self.context,orgs_deprecated)
 
         log.debug("orgs sync ok !")
+        return ldap_orgs_list
+
+    def sync_users(self, ldap_cnx, ldap_orgs_list ):
+        #TODO : there is certainly much room here for optimization...
+
+        roles = ldap_utils.get_roles_memberships(ldap_cnx)
+
+        all_users_by_groups = self.get_ckan_members_by_groups(ldap_orgs_list)
+        for org in ldap_orgs_list:
+            ldap_users_list = ldap_utils.get_ldap_org_members(ldap_cnx, org)
+            ckan_org_members_list = self.get_ckan_members_of_org(org)
+            for user in ldap_users_list:
+                #list the orgs he belongs in ckan
+                user_ckan_orgs = toolkit.get_action(
+                    'organization_list_for_user')(self.context, {'id':user['uid'], 'include_dataset_count': True})
+                if (len(user_ckan_orgs) > 1):
+                    raise Exception("oops")
+                elif (len(user_ckan_orgs) == 0):
+                    user_utils.create(self.context, user, org)
+                elif (user_ckan_orgs[0] == org['id']):
+                    user_utils.update(self.context, user, org)
+                else:
+                    user_utils.change_org(self.context, user, org)
+
+                log.debug("ok")
+            #users_exist = [ el for el in ldap_users_list if el['cn'] in ckan_org_members_list]
+            log.debug("ok")
 
     def get_ckan_orgs(self):
         orgs = toolkit.get_action('organization_list')(self.context, {'limit': 1000, 'all_fields':False})
         return orgs
+
+    def get_ckan_members_of_org(self, org):
+        users = toolkit.get_action('member_list')(self.context, {'id':org['id'], 'object_type': 'user'})
+        return users
+
+    def get_ckan_members_by_groups(self, orgs_list):
+        # This toolkit action doesn't seem to work... I get an empty list
+        groups_with_members = toolkit.get_action('organization_list')(self.context, {'limit':1000, 'all_fields':True,
+                                                                                     'include_users':True})
+        return groups_with_members

--- a/ckanext/georchestra/commands/georchestra_ldap.py
+++ b/ckanext/georchestra/commands/georchestra_ldap.py
@@ -54,72 +54,40 @@ class GeorchestraLDAPCommand(CkanCommand):
         log.setLevel(logging.DEBUG)
 
         ldap_cnx= ldap_utils.get_ldap_connection()
-        ldap_orgs_list = self.sync_organizations(ldap_cnx)
-        self.sync_users(ldap_cnx, ldap_orgs_list)
+        processed_orgs = self.sync_organizations(ldap_cnx)
+        self.sync_users(ldap_cnx)
         #self.sync_membership(ldap_cnx)
 
 
     def sync_organizations(self, ldap_cnx):
-        org_utils.preseed(self.clean_context())
-        ldap_orgs_list = ldap_utils.get_ldap_orgs(ldap_cnx)
+        #org_utils.preseed(self.clean_context())
+        processed_orgs = ldap_utils.orgs_scan_and_process(ldap_cnx, org_utils.update_or_create, self.clean_context())
         ckan_orgs_names_list = self.get_ckan_orgs()
 
-        ckan_orgs_set=set(ckan_orgs_names_list)
-
-        orgs_exist = [ el for el in ldap_orgs_list if el['id'] in ckan_orgs_set ]
-        orgs_missing = [ el for el in ldap_orgs_list if el['id'] not in ckan_orgs_set ]
-        orgs_deprecated = list( ckan_orgs_set - set([el['id'] for el in ldap_orgs_list]))
-
-        org_utils.update(self.clean_context(),orgs_exist, force_update=self.is_dev_mode)
-        org_utils.add(self.clean_context(),orgs_missing)
-        org_utils.remove(self.clean_context(),orgs_deprecated)
-
+        orgs_to_delete = set(ckan_orgs_names_list) - set (processed_orgs)
+        org_utils.remove(self.clean_context(), orgs_to_delete)
         log.debug("orgs sync ok !")
-        return ldap_orgs_list
+        return processed_orgs
 
-    def sync_users(self, ldap_cnx, ldap_orgs_list ):
-        """
-        Sync users and their membership to organizations.
-        In order not to overload the memory when huge user list is present, we "paginate"
-        by running the sync one organization at a time and then deleting people belonging
-        in no organization
-        :param ldap_cnx:
-        :param ldap_orgs_list:
-        :return:
-        """
-        #TODO : there is certainly much room here for optimization...
-
-        roles = ldap_utils.get_roles_memberships(ldap_cnx)
+    def sync_users(self, ldap_cnx):
+        processed_users = ldap_utils.users_scan_and_process(ldap_cnx, user_utils.update_or_create, self.clean_context())
+        ckan_users_list = self.get_ckan_users()
 
         # keep root sysadmin users (like the one running this current command) out of the sync process (we don't want
         # them removed...)
-        processed_userids = config['ckanext.georchestra.external_users'].split(",")
-        for ldap_org in ldap_orgs_list:
-            ldap_users_list = ldap_utils.get_ldap_org_members(ldap_cnx, ldap_org, roles)
-            #TODO: see if we shouldn't use instead toolkit.get_action('organization_list')(self.context, {'limit': 1000, 'all_fields':True, 'include_users':True, 'organizations':[org['id']]})
-            #to get a list of the users with capacity information
-            for ldap_user in  ldap_users_list:
-                try:
-                    log.debug("checking user {0}".format(ldap_user['id']))
-                    ckan_user = toolkit.get_action('user_show')(self.clean_context(), {'id':ldap_user['id']})
-                    # no exception means the user already exists in the DB
-                    user_utils.update(self.clean_context(), ldap_user, ckan_user, ldap_org)
-                except toolkit.ObjectNotFound:
-                    user_utils.create(self.clean_context(), ldap_user, ldap_org)
-                processed_userids.append(ldap_user['id'])
-
-        ckan_all_users = toolkit.get_action('user_list')(self.clean_context(), {'all_fields':False})
-        orphan_users = set(ckan_all_users)-set(processed_userids)
-        log.debug("there are {0} orphan users to remove".format(len(orphan_users)))
-        for orphan in orphan_users:
+        notouch_userids = config['ckanext.georchestra.external_users'].split(",")
+        users_to_delete = set(ckan_users_list) - set(processed_users + notouch_userids)
+        for orphan in users_to_delete:
             user_utils.delete(self.clean_context(), orphan, config['ckanext.georchestra.orphans.users.purge'])
+        log.debug("users sync ok !")
+        return processed_users
 
     def get_ckan_orgs(self):
         orgs = toolkit.get_action('organization_list')(self.clean_context(), {'limit': 1000, 'all_fields':False})
         return orgs
 
-    def get_ckan_members_of_org(self, org):
-        users = toolkit.get_action('member_list')(self.clean_context(), {'id':org['id'], 'object_type': 'user'})
+    def get_ckan_users(self):
+        users = toolkit.get_action('user_list')(self.clean_context(), {'all_fields': False})
         return users
 
     def clean_context(self):

--- a/ckanext/georchestra/commands/utils/ldap_utils.py
+++ b/ckanext/georchestra/commands/utils/ldap_utils.py
@@ -14,7 +14,7 @@ def get_ldap_connection():
     # TODO manage bytes_mode=False : see how to properly deal with unicode config. I can unicode(config[...]) every
     #      config file, but this looks dirty
     # TODO trace_level seems not possible to configure from ini files. Strange
-    cnx = ldap.initialize(config['ckanext.georchestra.ldap.uri'], bytes_mode=True, trace_level=2)
+    cnx = ldap.initialize(config['ckanext.georchestra.ldap.uri'], bytes_mode=True, trace_level=0)
 
     if config.get('ckanext.georchestra.ldap.auth.dn'):
         try:
@@ -58,8 +58,6 @@ def get_ldap_orgs(cnx):
                                       attrlist=['dn', 'cn', 'o', 'member', 'seeAlso', 'modifytimestamp'])
     ldap_orgs_list = []
     for elt in ldap_search_result:
-        ts = elt[1]['modifyTimestamp'][0]
-        log.debug("timestamp {0}".format(ts.decode('utf8')))
         org = {'name': elt[1]['cn'][0].decode('utf_8'),
                'id': elt[1]['cn'][0].decode('utf_8'),
                'title': elt[1]['o'][0].decode('utf_8'),
@@ -83,3 +81,51 @@ def get_ldap_orgs(cnx):
         ldap_orgs_list.append(org)
 
     return ldap_orgs_list
+
+def get_roles_memberships(cnx):
+    """
+    Collect the CKAN roles defined in the LDAP
+    :param cnx:
+    :return: a dict of role entries with, for each entry, the list of members (their DN)
+    """
+    ldap_roles_values = [config['ckanext.georchestra.role.sysadmin'],
+                         config['ckanext.georchestra.role.orgadmin'],
+                         config['ckanext.georchestra.role.editor']
+                         ]
+    ldap_filter = '(|'
+    for r in ldap_roles_values:
+        ldap_filter += '(cn=' + r + ')'
+    ldap_filter += ')'
+    ldap_search_result = cnx.search_s(config['ckanext.georchestra.ldap.base_dn.roles'], ldap.SCOPE_ONELEVEL,
+                                      filterstr=ldap_filter,
+                                      attrlist=['cn', 'member', 'description'])
+    roles = dict()
+    for el in ldap_search_result:
+        roles[el[1]['cn'][0].decode('utf_8')] = el[1]['member']
+    log.debug("ok")
+    return roles
+
+def get_ldap_org_members(cnx, org):
+    """
+    Collect LDAP users members of the given organization
+    (org is expected to ba a dict like provided by self.get_ldap_org with org['members'] list)
+    :return:
+    """
+    ldap_users_list = []
+    for member_dn in org['members']:
+        res = cnx.search_s(member_dn, ldap.SCOPE_BASE,
+                                      filterstr='(objectClass=person)',
+                                      attrlist=None)
+        user = {'dn': res[0][0].decode('utf_8'),
+                'uid': res[0][1]['uid'][0].decode('utf_8'),
+                'name': res[0][1]['uid'][0].decode('utf_8')+'2',
+                'id': res[0][1]['uid'][0].decode('utf_8')+'2',
+                'cn': res[0][1]['cn'][0].decode('utf_8'),
+                'about': res[0][1]['description'][0].decode('utf_8'),
+                'fullname:': res[0][1]['givenName'][0].decode('utf_8'),
+                'email': res[0][1]['mail'][0].decode('utf_8'),
+                'sn': res[0][1]['sn'][0].decode('utf_8'),
+                'password':'12345678'
+                }
+        ldap_users_list.append(user)
+    return ldap_users_list

--- a/ckanext/georchestra/commands/utils/ldap_utils.py
+++ b/ckanext/georchestra/commands/utils/ldap_utils.py
@@ -221,7 +221,7 @@ def user_format_and_complete(cnx, user):
                  'id': attr['uid'][0],
                  'cn': attr['cn'][0],
                  'about': attr['description'][0],
-                 'fullname': attr['givenName'][0],
+                 'fullname': attr['givenName'][0] + ' '+attr['sn'][0],
                  'display_name': attr['givenName'][0],
                  'email': attr['mail'][0],
                  'sn': attr['sn'][0],
@@ -238,6 +238,7 @@ def user_format_and_complete(cnx, user):
     }
 
     try:
+        #TODO: integrate this search in the main users search above. It probably don't need to run another search
         memberships = cnx.search_s(config['ckanext.georchestra.ldap.base_dn.users'],
                               ldap.SCOPE_ONELEVEL,
                               '(uid={0})'.format(user_dict['name']),

--- a/ckanext/georchestra/commands/utils/ldap_utils.py
+++ b/ckanext/georchestra/commands/utils/ldap_utils.py
@@ -1,0 +1,85 @@
+import logging
+import dateutil
+
+import ldap, ldap.filter
+
+from ckan.plugins.toolkit import config
+
+log = logging.getLogger()
+
+def get_ldap_connection():
+    """
+    :return: LDAP connection object
+    """
+    # TODO manage bytes_mode=False : see how to properly deal with unicode config. I can unicode(config[...]) every
+    #      config file, but this looks dirty
+    # TODO trace_level seems not possible to configure from ini files. Strange
+    cnx = ldap.initialize(config['ckanext.georchestra.ldap.uri'], bytes_mode=True, trace_level=2)
+
+    if config.get('ckanext.georchestra.ldap.auth.dn'):
+        try:
+            if config['ckanext.georchestra.ldap.auth.method'] == 'SIMPLE':
+                cnx.bind_s(config['ckanext.georchestra.ldap.auth.dn'],
+                           config['ckanext.georchestra.ldap.auth.password'])
+            elif config['ckanext.georchestra.ldap.auth.method'] == 'SASL':
+                if config['ckanext.georchestra.ldap.auth.mechanism'] == 'DIGEST-MD5':
+                    auth_tokens = ldap.sasl.digest_md5(config['ckanext.georchestra.ldap.auth.dn'],
+                                                       config['ckanext.georchestra.ldap.auth.password'])
+                    cnx.sasl_interactive_bind_s("", auth_tokens)
+                else:
+                    log.error("SASL mechanism not supported: {0}".format(
+                        config['ckanext.georchestra.ldap.auth.mechanism']))
+                    return None
+            else:
+                log.error(
+                    "LDAP authentication method is not supported: {0}".format(
+                        config['ckanext.georchestra.ldap.auth.method']))
+                return None
+        except ldap.SERVER_DOWN:
+            log.error('LDAP server is not reachable')
+            return None
+        except ldap.INVALID_CREDENTIALS:
+            log.error(
+                'LDAP server credentials (ckanext.georchestra.ldap.auth.dn and ckanext.georchestra.ldap.auth.password) invalid')
+            return None
+        except ldap.LDAPError, e:
+            log.error("Fatal LDAP Error: {0}".format(e))
+            return None
+    return cnx
+
+
+def get_ldap_orgs(cnx):
+    """
+    Get LDAP organization list
+    :return:
+    """
+    ldap_search_result = cnx.search_s(config['ckanext.georchestra.ldap.base_dn.orgs'], ldap.SCOPE_ONELEVEL,
+                                      filterstr='(objectClass=groupOfMembers)',
+                                      attrlist=['dn', 'cn', 'o', 'member', 'seeAlso', 'modifytimestamp'])
+    ldap_orgs_list = []
+    for elt in ldap_search_result:
+        ts = elt[1]['modifyTimestamp'][0]
+        log.debug("timestamp {0}".format(ts.decode('utf8')))
+        org = {'name': elt[1]['cn'][0].decode('utf_8'),
+               'id': elt[1]['cn'][0].decode('utf_8'),
+               'title': elt[1]['o'][0].decode('utf_8'),
+               'update_ts': dateutil.parser.parse(elt[1]['modifyTimestamp'][0].decode('utf_8'))
+               }
+        members = elt[1]['member']
+        members_list = []
+        for member in members:
+            members_list.append(member)
+        org['members'] = members_list
+
+        see_also_links = elt[1]['seeAlso']
+        for link in see_also_links:
+            res = cnx.search_s(link, ldap.SCOPE_BASE,
+                               filterstr='(objectClass=*)', attrlist=None)
+            if res[0][0].startswith('o='):
+                org['description'] = res[0][1]['description'][0]
+            else:
+                # org['image_url'] =  res[0][1]['jpegPhoto'][0]
+                pass
+        ldap_orgs_list.append(org)
+
+    return ldap_orgs_list

--- a/ckanext/georchestra/commands/utils/ldap_utils.py
+++ b/ckanext/georchestra/commands/utils/ldap_utils.py
@@ -132,7 +132,10 @@ def org_format_and_complete(cnx, org):
         res = cnx.search_s(link, ldap.SCOPE_BASE,
                            filterstr='(objectClass=*)', attrlist=None)
         if res[0][0].startswith('o='):
-            organization['description'] = res[0][1]['description'][0]
+            try :
+                organization['description'] = res[0][1]['description'][0]
+            except KeyError:
+                organization['description'] = ''
         else:
             #TODO retrieve the image data and try to store it as base64 encoded URL
             # org['image_url'] =  'data:image/jpeg;base64, '+res[0][1]['jpegPhoto'][0]
@@ -231,6 +234,7 @@ def user_format_and_complete(cnx, user):
                  'role': 'member'
                 }
 
+    prefix = config['ckanext.georchestra.role.prefix']
     ldap_roles_dict = {
         config['ckanext.georchestra.role.sysadmin']: 'sysadmin',
         config['ckanext.georchestra.role.orgadmin']: 'admin',
@@ -250,6 +254,7 @@ def user_format_and_complete(cnx, user):
                 continue
             for m in memberof_entries:
                 # get roles
+
                 rolere = re.search('cn=(.*),{0}'.format(config['ckanext.georchestra.ldap.base_dn.roles']), m)
                 if rolere:
                     rolename = rolere.group(1)

--- a/ckanext/georchestra/commands/utils/ldap_utils.py
+++ b/ckanext/georchestra/commands/utils/ldap_utils.py
@@ -122,7 +122,8 @@ def get_ldap_org_members(cnx, org):
                 'id': res[0][1]['uid'][0].decode('utf_8'),
                 'cn': res[0][1]['cn'][0].decode('utf_8'),
                 'about': res[0][1]['description'][0].decode('utf_8'),
-                'fullname:': res[0][1]['givenName'][0].decode('utf_8'),
+                'fullname': res[0][1]['givenName'][0].decode('utf_8'),
+                'display_name': res[0][1]['givenName'][0].decode('utf_8'),
                 'email': res[0][1]['mail'][0].decode('utf_8'),
                 'sn': res[0][1]['sn'][0].decode('utf_8'),
                 'password':'12345678'

--- a/ckanext/georchestra/commands/utils/ldap_utils.py
+++ b/ckanext/georchestra/commands/utils/ldap_utils.py
@@ -76,7 +76,8 @@ def get_ldap_orgs(cnx):
             if res[0][0].startswith('o='):
                 org['description'] = res[0][1]['description'][0]
             else:
-                # org['image_url'] =  res[0][1]['jpegPhoto'][0]
+                #TODO retrieve the image data and try to store it as base64 encoded URL
+                # org['image_url'] =  'data:image/jpeg;base64, '+res[0][1]['jpegPhoto'][0]
                 pass
         ldap_orgs_list.append(org)
 
@@ -129,7 +130,8 @@ def get_ldap_org_members(cnx, org, roles):
                 'sn': res[0][1]['sn'][0].decode('utf_8'),
                 'password':'12345678',
                 'role': get_user_role(res[0][0].decode('utf_8'), roles),
-                'sysadmin': (r=='sysadmin')
+                'sysadmin': (r=='sysadmin'),
+                'state': 'active'
                 }
         ldap_users_list.append(user)
     return ldap_users_list

--- a/ckanext/georchestra/commands/utils/ldap_utils.py
+++ b/ckanext/georchestra/commands/utils/ldap_utils.py
@@ -118,8 +118,8 @@ def get_ldap_org_members(cnx, org):
                                       attrlist=None)
         user = {'dn': res[0][0].decode('utf_8'),
                 'uid': res[0][1]['uid'][0].decode('utf_8'),
-                'name': res[0][1]['uid'][0].decode('utf_8')+'2',
-                'id': res[0][1]['uid'][0].decode('utf_8')+'2',
+                'name': res[0][1]['uid'][0].decode('utf_8'),
+                'id': res[0][1]['uid'][0].decode('utf_8'),
                 'cn': res[0][1]['cn'][0].decode('utf_8'),
                 'about': res[0][1]['description'][0].decode('utf_8'),
                 'fullname:': res[0][1]['givenName'][0].decode('utf_8'),

--- a/ckanext/georchestra/commands/utils/organizations.py
+++ b/ckanext/georchestra/commands/utils/organizations.py
@@ -2,6 +2,7 @@ import logging
 import dateutil
 
 from ckan.plugins import toolkit
+from ckan import model
 
 log = logging.getLogger()
 
@@ -40,6 +41,7 @@ def update(context, orgs_list, force_update=False):
                 # then we update it
                 log.debug("updating organization {0}".format(org['id']))
                 current_org = toolkit.get_action('organization_patch')(context, org)
+                flush()
         except:
             log.error("Could not read organization {0} (should exist though".format(org))
 
@@ -56,6 +58,7 @@ def remove(context, orgs_list):
     for org in orgs_list:
         try:
             toolkit.get_action('organization_purge')(context, {'id': org})
+            flush()
             log.debug("purged organization {0}".format(org))
         except:
             log.error("could not purge organization {0}".format(org))
@@ -68,6 +71,7 @@ def create(context, data_dict):
     try:
         log.debug("creating organization {0}".format(data_dict['id']))
         toolkit.get_action('organization_create')(context, data_dict)
+        flush()
     except Exception as e:
         log.error(e, exc_info=True)
 
@@ -92,6 +96,11 @@ def delete(context, id):
     context.pop('__auth_audit', None)
     try:
         toolkit.get_action('organization_purge')(context, {'id': id})
+        flush()
         log.debug("purged organization {0}".format(id))
     except Exception as e:
         log.error(e, exc_info=True)
+
+def flush():
+    model.Session.commit()
+    model.Session.remove()

--- a/ckanext/georchestra/commands/utils/organizations.py
+++ b/ckanext/georchestra/commands/utils/organizations.py
@@ -1,0 +1,95 @@
+import logging
+import dateutil
+
+from ckan.plugins import toolkit
+
+log = logging.getLogger()
+
+
+def preseed(context):
+    """
+    Clean the ckan instance
+    create some common orgs, some deprecated ones and leave some uncreated
+    :return:
+    """
+    create(context, {'id': 'fake', 'name': 'fake'})
+    for org in ['psc', 'c2c', 'cra']:
+        try:
+            toolkit.get_action('organization_purge')(context, {'id': org})
+            log.debug("purged organization {0}".format(org))
+            org = toolkit.get_action('organization_show')(context, {'id': org})
+            log.debug("organization {0} already exists".format(org))
+        except toolkit.ObjectNotFound:
+            # Means the organization was not found => we create it
+            if org in ['c2c', 'psc']:
+                create(context, {'id': org, 'name': org})
+        except Exception as e:
+            log.error(e, exc_info=True)
+
+def update(context, orgs_list):
+    for org in orgs_list:
+        try:
+            #current_org = toolkit.get_action('organization_show')(context, {'id': org['id'], 'include_extras':True})
+            revisions = toolkit.get_action('organization_revision_list')(context, {'id': org['id']})
+            # in order to be able to compare with LDAP timestamp, we need it to be seen as time-aware.
+            # TODO: check it is really UTC time always
+            #last_revision=dateutil.parser.parse(revisions[0]['timestamp']+'Z')
+            last_revision = dateutil.parser.parse('20190208085726Z')
+            if org['update_ts'] > last_revision:
+                # then we update it
+                log.debug("updating organization {0}".format(org['id']))
+                current_org = toolkit.get_action('organization_patch')(context, org)
+            log.debug("ok")
+        except:
+            log.error("Could not read organization {0} (should exist though".format(org))
+
+def add(context, orgs_list):
+    # trick to solve this SQLalchemy flushing issue. It seems 'group' info stays present in the self.session and
+    # messes things up. Clearing the 'group' var seems to help.
+    context['group'] = None
+    for org in orgs_list:
+        create(context,org)
+        log.debug("added organization {0}".format(org['id']))
+
+def remove(context, orgs_list):
+    # TODO : check content and move all packages to a 'ghost' org before purging org
+    for org in orgs_list:
+        try:
+            toolkit.get_action('organization_purge')(context, {'id': org})
+            log.debug("purged organization {0}".format(org))
+        except:
+            log.error("could not purge organization {0}".format(org))
+
+
+def create(context, data_dict):
+    # Apply auth fix from https://github.com/datagovuk/ckanext-harvest/commit/f315f41c86cbde4a49ef869b6993598f8cb11e2d
+    # to error message Action function organization_show did not call its auth function
+    context.pop('__auth_audit', None)
+    try:
+        log.debug("creating organization {0}".format(data_dict['id']))
+        toolkit.get_action('organization_create')(context, data_dict)
+    except Exception as e:
+        log.error(e, exc_info=True)
+
+
+def delete(context, id):
+    # TODO : resolve bug, see comment underneath
+    """
+    Don't use it. It generates an error from sqlalchemy :
+    related attribute set' operation is not currently supported within the execution stage of the flush process
+    already reported and closed (https://github.com/ckan/ckan/issues/2017). See if I can identify it or propose a
+    reliable way to reproduce ut (seems pretty reliable right now : just run twice organization_delete then some
+    organization_create and it all goes weird. For instance, my preseed function was like this :
+    for org in ['psc', 'c2c', 'cra', 'fake']:
+        self.organization_delete(org)
+
+    self.organization_create("c2c", None))
+    self.organization_create("fake", None)
+    and it would not create c2c organization, after issuing the sqlalchemy error)
+    """
+    context.pop('__auth_audit', None)
+    try:
+        toolkit.get_action('organization_purge')(context, {'id': id})
+        log.debug("purged organization {0}".format(id))
+    except Exception as e:
+        log.error(e, exc_info=True)

--- a/ckanext/georchestra/commands/utils/organizations.py
+++ b/ckanext/georchestra/commands/utils/organizations.py
@@ -87,6 +87,7 @@ def delete(context, id):
     self.organization_create("c2c", None))
     self.organization_create("fake", None)
     and it would not create c2c organization, after issuing the sqlalchemy error)
+    I may have a lead looking at https://github.com/ckan/ckan/blob/master/ckan/logic/action/create.py#L964
     """
     context.pop('__auth_audit', None)
     try:

--- a/ckanext/georchestra/commands/utils/organizations.py
+++ b/ckanext/georchestra/commands/utils/organizations.py
@@ -28,38 +28,34 @@ def preseed(context):
         except Exception as e:
             log.error(e, exc_info=True)
 
-def update(context, orgs_list, force_update=False):
-    for org in orgs_list:
-        try:
-            #current_org = toolkit.get_action('organization_show')(context, {'id': org['id'], 'include_extras':True})
-            revisions = toolkit.get_action('organization_revision_list')(context.copy(), {'id': org['id']})
-            # in order to be able to compare with LDAP timestamp, we need it to be seen as time-aware.
-            # TODO: check it is really UTC time always
-            last_revision = dateutil.parser.parse(revisions[0]['timestamp']+'Z')
-            #last_revision = dateutil.parser.parse('20190208085726Z')
-            if (org['update_ts'] > last_revision) or force_update:
-                # then we update it
-                log.debug("updating organization {0}".format(org['id']))
-                current_org = toolkit.get_action('organization_patch')(context.copy(), org)
-        except:
-            log.error("Could not read organization {0} (should exist though".format(org))
 
-def add(context, orgs_list):
-    # trick to solve this SQLalchemy flushing issue. It seems 'group' info stays present in the self.session and
-    # messes things up. Clearing the 'group' var seems to help.
-    context['group'] = None
-    for org in orgs_list:
-        create(context,org)
-        log.debug("added organization {0}".format(org['id']))
+def update_or_create(context, org, force_update=False):
+    try:
+        revisions = toolkit.get_action('organization_revision_list')(context.copy(), {'id': org['id']})
+        # If no error, also means the org exists
+
+        # in order to be able to compare with LDAP timestamp, we need it to be seen as time-aware.
+        # TODO: check it is really UTC time always
+        last_revision = dateutil.parser.parse(revisions[0]['timestamp'] + 'Z')
+
+        #last_revision = dateutil.parser.parse('20190208085726Z')
+        if (org['update_ts'] > last_revision) or force_update:
+            # then we update it
+            log.debug("updating organization {0}".format(org['name']))
+            current_org = toolkit.get_action('organization_patch')(context.copy(), org)
+        else:
+            log.debug("Organization {0} is up-to-date".format(org['id']))
+    except toolkit.ObjectNotFound:
+        # Means it doesn't exist yet => we create it
+        log.debug("Creating organization {0}".format(org['name']))
+        create(context, org)
+    pass
+
 
 def remove(context, orgs_list):
-    # TODO : check content and move all packages to a 'ghost' org before purging org
     for org in orgs_list:
-        try:
-            toolkit.get_action('organization_purge')(context.copy(), {'id': org})
-            log.debug("purged organization {0}".format(org))
-        except:
-            log.error("could not purge organization {0}".format(org))
+        delete(context, org)
+        log.debug("purged organization {0}".format(org))
 
 
 def create(context, data_dict):
@@ -74,28 +70,13 @@ def create(context, data_dict):
 
 
 def delete(context, id):
-    # TODO : resolve bug, see comment underneath
-    #TODO: check if it could not be solved for instance by calling action('user_create') see https://github.com/ckan/ckan/blob/2.8/ckan/logic/action/create.py#L968
-    """
-    Don't use it. It generates an error from sqlalchemy :
-    related attribute set' operation is not currently supported within the execution stage of the flush process
-    already reported and closed (https://github.com/ckan/ckan/issues/2017). See if I can identify it or propose a
-    reliable way to reproduce ut (seems pretty reliable right now : just run twice organization_delete then some
-    organization_create and it all goes weird. For instance, my preseed function was like this :
-    for org in ['psc', 'c2c', 'cra', 'fake']:
-        self.organization_delete(org)
-
-    self.organization_create("c2c", None))
-    self.organization_create("fake", None)
-    and it would not create c2c organization, after issuing the sqlalchemy error)
-    I may have a lead looking at https://github.com/ckan/ckan/blob/master/ckan/logic/action/create.py#L964
-    """
+    # TODO : check content and move all packages to a 'ghost' org before purging org
     context.pop('__auth_audit', None)
     try:
         toolkit.get_action('organization_purge')(context.copy(), {'id': id})
         flush()
         log.debug("purged organization {0}".format(id))
-    except Exception as e:
+    except Exception, e:
         log.error(e, exc_info=True)
 
 def flush():

--- a/ckanext/georchestra/commands/utils/organizations.py
+++ b/ckanext/georchestra/commands/utils/organizations.py
@@ -74,6 +74,7 @@ def create(context, data_dict):
 
 def delete(context, id):
     # TODO : resolve bug, see comment underneath
+    #TODO: check if it could not be solved for instance by calling action('user_create') see https://github.com/ckan/ckan/blob/2.8/ckan/logic/action/create.py#L968
     """
     Don't use it. It generates an error from sqlalchemy :
     related attribute set' operation is not currently supported within the execution stage of the flush process

--- a/ckanext/georchestra/commands/utils/organizations.py
+++ b/ckanext/georchestra/commands/utils/organizations.py
@@ -17,9 +17,9 @@ def preseed(context):
     # for org in ['psc', 'c2c', 'cra']:
     for org in ['c2c']:
         try:
-            toolkit.get_action('organization_purge')(context, {'id': org})
+            toolkit.get_action('organization_purge')(context.copy(), {'id': org})
             log.debug("purged organization {0}".format(org))
-            org = toolkit.get_action('organization_show')(context, {'id': org})
+            org = toolkit.get_action('organization_show')(context.copy(), {'id': org})
             log.debug("organization {0} already exists".format(org))
         except toolkit.ObjectNotFound:
             # Means the organization was not found => we create it
@@ -32,7 +32,7 @@ def update(context, orgs_list, force_update=False):
     for org in orgs_list:
         try:
             #current_org = toolkit.get_action('organization_show')(context, {'id': org['id'], 'include_extras':True})
-            revisions = toolkit.get_action('organization_revision_list')(context, {'id': org['id']})
+            revisions = toolkit.get_action('organization_revision_list')(context.copy(), {'id': org['id']})
             # in order to be able to compare with LDAP timestamp, we need it to be seen as time-aware.
             # TODO: check it is really UTC time always
             last_revision = dateutil.parser.parse(revisions[0]['timestamp']+'Z')
@@ -40,8 +40,7 @@ def update(context, orgs_list, force_update=False):
             if (org['update_ts'] > last_revision) or force_update:
                 # then we update it
                 log.debug("updating organization {0}".format(org['id']))
-                current_org = toolkit.get_action('organization_patch')(context, org)
-                flush()
+                current_org = toolkit.get_action('organization_patch')(context.copy(), org)
         except:
             log.error("Could not read organization {0} (should exist though".format(org))
 
@@ -57,8 +56,7 @@ def remove(context, orgs_list):
     # TODO : check content and move all packages to a 'ghost' org before purging org
     for org in orgs_list:
         try:
-            toolkit.get_action('organization_purge')(context, {'id': org})
-            flush()
+            toolkit.get_action('organization_purge')(context.copy(), {'id': org})
             log.debug("purged organization {0}".format(org))
         except:
             log.error("could not purge organization {0}".format(org))
@@ -70,8 +68,7 @@ def create(context, data_dict):
     context.pop('__auth_audit', None)
     try:
         log.debug("creating organization {0}".format(data_dict['id']))
-        toolkit.get_action('organization_create')(context, data_dict)
-        flush()
+        toolkit.get_action('organization_create')(context.copy(), data_dict)
     except Exception as e:
         log.error(e, exc_info=True)
 
@@ -95,7 +92,7 @@ def delete(context, id):
     """
     context.pop('__auth_audit', None)
     try:
-        toolkit.get_action('organization_purge')(context, {'id': id})
+        toolkit.get_action('organization_purge')(context.copy(), {'id': id})
         flush()
         log.debug("purged organization {0}".format(id))
     except Exception as e:

--- a/ckanext/georchestra/commands/utils/users.py
+++ b/ckanext/georchestra/commands/utils/users.py
@@ -7,52 +7,48 @@ import ckan.model as model
 log = logging.getLogger()
 
 
-def update(context, user, ckan_user,org, force_update=False):
+def update(context, ldap_user, ckan_user, org, force_update=False):
     # note : ckan does not provide revisions for user profile. This means we can't check timestamps.
     # so we use the user's profile, and check for differences on synced attributes
     #ckan_user = toolkit.get_action('user_show')(context, {'id':user['id']})
 
     # Update user profile
-    diff = { k : ckan_user[k] for k in set(ckan_user)-set(user)}
+    diff = {k : ckan_user[k] for k in set(ckan_user) - set(ldap_user)}
     check_fields=['name','email', 'about','fullname', 'display_name','sysadmin', 'state']
-    checks = [(ckan_user[f]!= user[f]) for f in check_fields]
+    checks = [(ckan_user[f] != ldap_user[f]) for f in check_fields]
     needs_update=reduce(lambda x,y: x or y, checks)
     if needs_update or force_update:
-        ckan_user = toolkit.get_action('user_update')(context, user)
+        ckan_user = toolkit.get_action('user_update')(context, ldap_user)
         flush()
-        log.debug("updated user {0}".format(user['id']))
+        log.debug("updated user {0}".format(ldap_user['id']))
 
     # Update user membership to organizations
-    if (user['role']!='sysadmin'):
-        #TODO: check if role changed
+    if (ldap_user['role']!= 'sysadmin'):
         updated_membership = False
-        user_orgs_list = toolkit.get_action('organization_list_for_user')(context, {'id':user['id']})
+        # Update membership on all organizations he belongs
+        user_orgs_list = toolkit.get_action('organization_list_for_user')(context, {'id':ldap_user['id']})
         for o in user_orgs_list:
-            log.debug("updating user {0} membership for organization {1}".format(user['id'], o['id']))
+            log.debug("updating user {0} membership for organization {1}".format(ldap_user['id'], o['id']))
             if o['id'] == org['id']:
-                if o['capacity'] != user['role']:
-                    log.debug("changed {0} role for ".format(user['id'], o['id']))
+                if o['capacity'] != ldap_user['role']:
+                    log.debug("changed {0} role for ".format(ldap_user['id'], o['id']))
                     toolkit.get_action('organization_member_create')(context,
-                                                     {'id': org['id'], 'username': user['id'], 'role':user['role']})
+                                                                     {'id': org['id'], 'username': ldap_user['id'],
+                                                                      'role':ldap_user['role']})
                     flush()
                 updated_membership=True
             else:
-                log.debug("removing user {0} from organization {1}".format(user['id'], o['id']))
-                toolkit.get_action('organization_member_delete')(context, {'id': org['id'], 'username': user['id']})
+                log.debug("removing user {0} from organization {1}".format(ldap_user['id'], o['id']))
+                toolkit.get_action('organization_member_delete')(context, {'id': org['id'],
+                                                                           'username': ldap_user['id']})
                 flush()
+        # He not not have belonged to the current org. This is dealt with here
         if not updated_membership:
             toolkit.get_action('organization_member_create')(context,
-                                                         {'id': org['id'], 'username': user['name'],
-                                                          'role': user['role']})
+                                                             {'id': org['id'], 'username': ldap_user['name'],
+                                                              'role': ldap_user['role']})
 
     return ckan_user
-
-def add(context, orgs_list):
-    pass
-
-def remove(context, orgs_list):
-    pass
-
 
 def create(context, user, org):
     # Apply auth fix from https://github.com/datagovuk/ckanext-harvest/commit/f315f41c86cbde4a49ef869b6993598f8cb11e2d
@@ -66,7 +62,8 @@ def create(context, user, org):
 
         if (user['role'] != 'sysadmin'):
             # add it as member of the organization
-            toolkit.get_action('organization_member_create')(context, {'id':org['id'], 'username':user['id'], 'role':user['role']})
+            toolkit.get_action('organization_member_create')(context, {'id': org['id'], 'username': user['id'],
+                                                                       'role': user['role']})
             flush()
     except Exception as e:
         log.error(e, exc_info=True)

--- a/ckanext/georchestra/commands/utils/users.py
+++ b/ckanext/georchestra/commands/utils/users.py
@@ -6,73 +6,30 @@ from ckan.plugins import toolkit
 log = logging.getLogger()
 
 
-def update(context, orgs_list, force_update=False):
-    for org in orgs_list:
-        try:
-            #current_org = toolkit.get_action('organization_show')(context, {'id': org['id'], 'include_extras':True})
-            revisions = toolkit.get_action('organization_revision_list')(context, {'id': org['id']})
-            # in order to be able to compare with LDAP timestamp, we need it to be seen as time-aware.
-            # TODO: check it is really UTC time always
-            last_revision = dateutil.parser.parse(revisions[0]['timestamp']+'Z')
-            #last_revision = dateutil.parser.parse('20190208085726Z')
-            if (org['update_ts'] > last_revision) or force_update:
-                # then we update it
-                log.debug("updating organization {0}".format(org['id']))
-                current_org = toolkit.get_action('organization_patch')(context, org)
-        except:
-            log.error("Could not read organization {0} (should exist though".format(org))
+def update(context, user, force_update=False):
+    # TODO: check timestamps to determine if we update or no
+    ckan_user = toolkit.get_action('user_update')(context, user)
+    log.debug("updated user {0}".format(user['id']))
+    return ckan_user
 
 def add(context, orgs_list):
-    # trick to solve this SQLalchemy flushing issue. It seems 'group' info stays present in the self.session and
-    # messes things up. Clearing the 'group' var seems to help.
-    context['group'] = None
-    for org in orgs_list:
-        create(context,org)
-        log.debug("added organization {0}".format(org['id']))
+    pass
 
 def remove(context, orgs_list):
-    # TODO : check content and move all packages to a 'ghost' org before purging org
-    for org in orgs_list:
-        try:
-            toolkit.get_action('organization_purge')(context, {'id': org})
-            log.debug("purged organization {0}".format(org))
-        except:
-            log.error("could not purge organization {0}".format(org))
+    pass
 
 
-def create(context, user, org):
+def create(context, user):
     # Apply auth fix from https://github.com/datagovuk/ckanext-harvest/commit/f315f41c86cbde4a49ef869b6993598f8cb11e2d
     # to error message Action function organization_show did not call its auth function
     context.pop('__auth_audit', None)
     ckan_user = None
     try:
         ckan_user = toolkit.get_action('user_create')(context, user)
-        ckan_user = toolkit.get_action('organization_member_create')(context, {'id':org['id'], 'username': user['name'],
-                                                                               'role':'editor'})
-
+        log.debug("created user {0}".format(user['id']))
     except Exception as e:
         log.error(e, exc_info=True)
     return ckan_user
 
-
 def delete(context, id):
-    # TODO : resolve bug, see comment underneath
-    """
-    Don't use it. It generates an error from sqlalchemy :
-    related attribute set' operation is not currently supported within the execution stage of the flush process
-    already reported and closed (https://github.com/ckan/ckan/issues/2017). See if I can identify it or propose a
-    reliable way to reproduce ut (seems pretty reliable right now : just run twice organization_delete then some
-    organization_create and it all goes weird. For instance, my preseed function was like this :
-    for org in ['psc', 'c2c', 'cra', 'fake']:
-        self.organization_delete(org)
-
-    self.organization_create("c2c", None))
-    self.organization_create("fake", None)
-    and it would not create c2c organization, after issuing the sqlalchemy error)
-    """
-    context.pop('__auth_audit', None)
-    try:
-        toolkit.get_action('organization_purge')(context, {'id': id})
-        log.debug("purged organization {0}".format(id))
-    except Exception as e:
-        log.error(e, exc_info=True)
+    pass

--- a/ckanext/georchestra/commands/utils/users.py
+++ b/ckanext/georchestra/commands/utils/users.py
@@ -25,23 +25,25 @@ def update(context, user, ckan_user,org, force_update=False):
     # Update user membership to organizations
     if (user['role']!='sysadmin'):
         #TODO: check if role changed
+        updated_membership = False
         user_orgs_list = toolkit.get_action('organization_list_for_user')(context, {'id':user['id']})
-        toolkit.get_action('organization_member_create')(context,
-                                                         {'id': org['id'], 'username': user['id'],
-                                                          'role': user['role']})
         for o in user_orgs_list:
             log.debug("updating user {0} membership for organization {1}".format(user['id'], o['id']))
             if o['id'] == org['id']:
-                log.debug("making user {0} member of organization {1}".format(user['id'], o['id']))
                 if o['capacity'] != user['role']:
                     log.debug("changed {0} role for ".format(user['id'], o['id']))
                     toolkit.get_action('organization_member_create')(context,
                                                      {'id': org['id'], 'username': user['id'], 'role':user['role']})
                     flush()
+                updated_membership=True
             else:
                 log.debug("removing user {0} from organization {1}".format(user['id'], o['id']))
                 toolkit.get_action('organization_member_delete')(context, {'id': org['id'], 'username': user['id']})
                 flush()
+        if not updated_membership:
+            toolkit.get_action('organization_member_create')(context,
+                                                         {'id': org['id'], 'username': user['name'],
+                                                          'role': user['role']})
 
     return ckan_user
 

--- a/ckanext/georchestra/commands/utils/users.py
+++ b/ckanext/georchestra/commands/utils/users.py
@@ -12,19 +12,37 @@ def update(context, user, ckan_user,org, force_update=False):
     # so we use the user's profile, and check for differences on synced attributes
     #ckan_user = toolkit.get_action('user_show')(context, {'id':user['id']})
 
+    # Update user profile
     diff = { k : ckan_user[k] for k in set(ckan_user)-set(user)}
     check_fields=['name','email', 'about','fullname', 'display_name','sysadmin', 'state']
     checks = [(ckan_user[f]!= user[f]) for f in check_fields]
     needs_update=reduce(lambda x,y: x or y, checks)
     if needs_update or force_update:
         ckan_user = toolkit.get_action('user_update')(context, user)
+        flush()
         log.debug("updated user {0}".format(user['id']))
 
-    # TODO: remove user from other orgs
+    # Update user membership to organizations
     if (user['role']!='sysadmin'):
         #TODO: check if role changed
+        user_orgs_list = toolkit.get_action('organization_list_for_user')(context, {'id':user['id']})
         toolkit.get_action('organization_member_create')(context,
+                                                         {'id': org['id'], 'username': user['id'],
+                                                          'role': user['role']})
+        for o in user_orgs_list:
+            log.debug("updating user {0} membership for organization {1}".format(user['id'], o['id']))
+            if o['id'] == org['id']:
+                log.debug("making user {0} member of organization {1}".format(user['id'], o['id']))
+                if o['capacity'] != user['role']:
+                    log.debug("changed {0} role for ".format(user['id'], o['id']))
+                    toolkit.get_action('organization_member_create')(context,
                                                      {'id': org['id'], 'username': user['id'], 'role':user['role']})
+                    flush()
+            else:
+                log.debug("removing user {0} from organization {1}".format(user['id'], o['id']))
+                toolkit.get_action('organization_member_delete')(context, {'id': org['id'], 'username': user['id']})
+                flush()
+
     return ckan_user
 
 def add(context, orgs_list):
@@ -47,10 +65,31 @@ def create(context, user, org):
         if (user['role'] != 'sysadmin'):
             # add it as member of the organization
             toolkit.get_action('organization_member_create')(context, {'id':org['id'], 'username':user['id'], 'role':user['role']})
+            flush()
     except Exception as e:
         log.error(e, exc_info=True)
     return ckan_user
 
-def delete(context, id):
-    r = { }
-    pass
+def delete(context, id, purge=True):
+    """
+    remove a user from the users list
+    :param id(string): id of the user to delete
+    :param purge (Boolean): purge or simply set as 'state':'deleted'. (optional, default:True)
+    :return:
+    """
+    try:
+        if purge:
+            # toolkit.get_action('user_delete')(self.context, {'id': orphan})
+            # Beware : user_delete doesn't purge the user, it just shows it as deleted state.
+            # This is how to do it (cf https://stackoverflow.com/questions/33881318/how-to-completely-delete-a-ckan-user)
+            model.User.get(id).purge()
+            flush()
+        else:
+            toolkit.get_action('user_delete')(context, {'id': id})
+    except toolkit.ObjectNotFound, e:
+        log.error("Not found orphan user when trying to remove it: {0}".format(e))
+
+
+def flush():
+    model.Session.commit()
+    model.Session.remove()

--- a/ckanext/georchestra/commands/utils/users.py
+++ b/ckanext/georchestra/commands/utils/users.py
@@ -2,23 +2,25 @@ import logging
 import dateutil
 
 from ckan.plugins import toolkit
+import ckan.model as model
 
 log = logging.getLogger()
 
 
-def update(context, user, org, force_update=False):
+def update(context, user, ckan_user,org, force_update=False):
     # note : ckan does not provide revisions for user profile. This means we can't check timestamps.
-    # so we get the user's profile, and check for differences on synced attributes
-    ckan_user = toolkit.get_action('user_show')(context, {'id':user['id']})
+    # so we use the user's profile, and check for differences on synced attributes
+    #ckan_user = toolkit.get_action('user_show')(context, {'id':user['id']})
 
     diff = { k : ckan_user[k] for k in set(ckan_user)-set(user)}
-    check_fields=['name','email', 'about','fullname', 'display_name','sysadmin']
+    check_fields=['name','email', 'about','fullname', 'display_name','sysadmin', 'state']
     checks = [(ckan_user[f]!= user[f]) for f in check_fields]
     needs_update=reduce(lambda x,y: x or y, checks)
     if needs_update or force_update:
         ckan_user = toolkit.get_action('user_update')(context, user)
         log.debug("updated user {0}".format(user['id']))
 
+    # TODO: remove user from other orgs
     if (user['role']!='sysadmin'):
         #TODO: check if role changed
         toolkit.get_action('organization_member_create')(context,

--- a/ckanext/georchestra/commands/utils/users.py
+++ b/ckanext/georchestra/commands/utils/users.py
@@ -6,17 +6,23 @@ from ckan.plugins import toolkit
 log = logging.getLogger()
 
 
-def update(context, user, force_update=False):
+def update(context, user, org, force_update=False):
     # note : ckan does not provide revisions for user profile. This means we can't check timestamps.
     # so we get the user's profile, and check for differences on synced attributes
     ckan_user = toolkit.get_action('user_show')(context, {'id':user['id']})
+
     diff = { k : ckan_user[k] for k in set(ckan_user)-set(user)}
-    check_fields=['id', 'name','email', 'about','fullname', 'display_name']
+    check_fields=['name','email', 'about','fullname', 'display_name','sysadmin']
     checks = [(ckan_user[f]!= user[f]) for f in check_fields]
     needs_update=reduce(lambda x,y: x or y, checks)
     if needs_update or force_update:
         ckan_user = toolkit.get_action('user_update')(context, user)
         log.debug("updated user {0}".format(user['id']))
+
+    if (user['role']!='sysadmin'):
+        #TODO: check if role changed
+        toolkit.get_action('organization_member_create')(context,
+                                                     {'id': org['id'], 'username': user['id'], 'role':user['role']})
     return ckan_user
 
 def add(context, orgs_list):
@@ -26,17 +32,23 @@ def remove(context, orgs_list):
     pass
 
 
-def create(context, user):
+def create(context, user, org):
     # Apply auth fix from https://github.com/datagovuk/ckanext-harvest/commit/f315f41c86cbde4a49ef869b6993598f8cb11e2d
     # to error message Action function organization_show did not call its auth function
     context.pop('__auth_audit', None)
     ckan_user = None
     try:
+        # create user
         ckan_user = toolkit.get_action('user_create')(context, user)
         log.debug("created user {0}".format(user['id']))
+
+        if (user['role'] != 'sysadmin'):
+            # add it as member of the organization
+            toolkit.get_action('organization_member_create')(context, {'id':org['id'], 'username':user['id'], 'role':user['role']})
     except Exception as e:
         log.error(e, exc_info=True)
     return ckan_user
 
 def delete(context, id):
+    r = { }
     pass

--- a/ckanext/georchestra/commands/utils/users.py
+++ b/ckanext/georchestra/commands/utils/users.py
@@ -28,20 +28,24 @@ def update_or_create(context, user, force_update=False):
             updated_membership = False
             # Update membership on all organizations he belongs to (we remove him from all except the one listed in
             # his LDAP profile
-            user_orgs_list = toolkit.get_action('organization_list_for_user')(context.copy(), {'id': user['id']})
-            for o in user_orgs_list:
-                log.debug("updating user {0} membership for organization {1}".format(user['id'], o['id']))
-                if ('orgid' in user) and (o['id'] == user['orgid']):
-                    if o['capacity'] != user['role']:
-                        log.debug("changed {0} role for ".format(user['name'], o['id']))
-                        toolkit.get_action('organization_member_create')(context.copy(),
-                                                                         {'id': user['orgid'], 'username': user['name'],
-                                                                          'role': user['role']})
-                    updated_membership = True
-                else:
-                    log.debug("removing user {0} from organization {1}".format(user['name'], o['id']))
-                    toolkit.get_action('organization_member_delete')(context.copy(), {'id': user['orgid'],
+            try:
+                user_orgs_list = toolkit.get_action('organization_list_for_user')(context.copy(), {'id': user['id']})
+                for o in user_orgs_list:
+                    log.debug("updating user {0} membership for organization {1}".format(user['id'], o['id']))
+                    if ('orgid' in user) and (o['id'] == user['orgid']):
+                        if o['capacity'] != user['role']:
+                            log.debug("changed {0} role for ".format(user['name'], o['id']))
+                            toolkit.get_action('organization_member_create')(context.copy(),
+                                                                             {'id': user['orgid'], 'username': user['name'],
+                                                                              'role': user['role']})
+                        updated_membership = True
+                    else:
+                        log.debug("removing user {0} from organization {1}".format(user['name'], o['id']))
+                        toolkit.get_action('organization_member_delete')(context.copy(), {'id': user['orgid'],
                                                                                       'username': user['name']})
+            except toolkit.ObjectNotFound as e:
+                # this should not happen
+                log.error(e, exc_info=True)
             # He not not have belonged to the current org. This is dealt with here
             if ('orgid' in user) and ( not updated_membership):
                 toolkit.get_action('organization_member_create')(context.copy(),

--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -1,8 +1,11 @@
+import logging
+
+from hashlib import md5
+
 import ckan.plugins as plugins
 import ckan.model as model
 import ckan.plugins.toolkit as toolkit
-from hashlib import md5
-import logging
+from ckan.plugins.toolkit import config
 
 HEADER_USERNAME = "sec-username"
 HEADER_ROLES = "sec-roles"
@@ -25,4 +28,93 @@ log = logging.getLogger(__name__)
 
 
 class GeorchestraPlugin(plugins.SingletonPlugin):
-    pass
+    plugins.implements(plugins.IAuthenticator)
+    #TODO add IConfigurable implementation as in https://github.com/NaturalHistoryMuseum/ckanext-ldap/blob/master/ckanext/ldap/plugin.py
+
+    ldap_roles_dict = {
+        config['ckanext.georchestra.role.sysadmin']: 'sysadmin',
+        config['ckanext.georchestra.role.orgadmin']: 'admin',
+        config['ckanext.georchestra.role.editor']: 'editor'
+    }
+
+    # ignore basic auth actions
+    def login(self):
+        """Implementation of IAuthenticator.login"""
+        pass
+
+    def logout(self):
+        """Implementation of IAuthenticator.logout"""
+        #TODO: check if we don't need to somewhat clear the session
+        pass
+
+    def abort(self, status_code, detail, headers, comment):
+        """Implementation of IAuthenticator.abort"""
+        return status_code, detail, headers, comment
+
+    def identify(self):
+        """Implementation of IAuthenticator.identify
+        Used to determine the currently logged in user
+        Will first check if a username is available and act accordingly (get existing user, create new one)
+        """
+        user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
+        self.site_user_name = user['name']
+        self.context = {'user': user['name']}
+
+        headers = toolkit.request.headers
+        username = headers.get(HEADER_USERNAME)
+        if username:
+            email = headers.get(HEADER_EMAIL) or 'empty@empty.org'
+            emailhash = md5(email.strip().lower().encode('utf8')).hexdigest()
+            firstname = headers.get(HEADER_FIRSTNAME) or 'john'
+            lastname = headers.get(HEADER_LASTNAME) or 'doe'
+            roles = headers.get(HEADER_ROLES)
+            role = 'member' # default
+            if roles:
+                for r in roles.split(","):
+                    if r in self.ldap_roles_dict:
+                        role = self.ldap_roles_dict[r]
+                        break
+            userdict = {
+                'id': username,
+                'email': email,
+                'name': username,
+                'fullname': firstname + ' ' + lastname,
+                'password': '12345678',
+                'role': role,
+                'sysadmin': (role=='sysadmin'),
+                'state': 'active'
+            }
+            try:
+                ckan_user = toolkit.get_action('user_show')(self.context, {'id': userdict['name']})
+
+                # Check if the user needs to be updated
+                check_fields = ['name', 'email', 'fullname', 'sysadmin', 'state']
+                checks = [(ckan_user[f] != userdict[f]) for f in check_fields]
+                needs_update = reduce(lambda x, y: x or y, checks)
+                if needs_update:
+                    ckan_user = toolkit.get_action('user_update')(self.context, userdict)
+                    log.debug("updated user {0}".format(userdict['name']))
+                else:
+                    log.debug("user {0} is up-to-date".format(userdict['name']))
+
+                toolkit.c.user = ckan_user['name']
+                toolkit.c.user_obj = ckan_user
+
+                #TODO check if user membership needs updating and if needs organization to be created
+            except toolkit.ObjectNotFound:
+                # Means it doesn't exist yet => we create it
+                self.create_userdict(userdict)
+
+            toolkit.c.user = username
+            toolkit.c.user_obj = ckan_user
+        else:
+            toolkit.c.user = None
+
+    def create_user(self, userdict):
+        try:
+            ckan_user = toolkit.get_action('user_create')(context.copy(), user)
+            log.debug("created user {0}".format(user['id']))
+            # TODO check organization existence
+            # TODO add membership to org
+        except ValidationError, e:
+            log.error("User parameters are invalid. Could create the user. {0}".format(e))

--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -16,7 +16,7 @@ HEADER_TEL = "sec-tel"
 def auth_function_disabled(context, data_dict=None):
     # TODO : consider to return true in some "sysadmin" context. For instance to create organization
     return {
-        'success': False,
+        'success': True,
         'msg': 'Authentication is disabled on CKAN and is handled by geOrchestra.'
     }
 
@@ -25,116 +25,4 @@ log = logging.getLogger(__name__)
 
 
 class GeorchestraPlugin(plugins.SingletonPlugin):
-    plugins.implements(plugins.IAuthenticator)
-    plugins.implements(plugins.IAuthFunctions)
-    plugins.implements(plugins.IConfigurer)
-
-    # ignore basic auth actions
-    def login(self):
-        pass
-
-    def logout(self):
-        pass
-
-    def abort(self, status_code, detail, headers, comment):
-        pass
-
-    def identify(self):
-        """
-        Used to determine the currently logged in user
-        Will first check if a username is available and act accordingly (get existing user, create new one)
-        """
-        headers = toolkit.request.headers
-        username = headers.get(HEADER_USERNAME)
-        if username:
-            email = headers.get(HEADER_EMAIL) or 'empty@empty.org'
-            emailhash = md5(email.strip().lower().encode('utf8')).hexdigest()
-            firstname = headers.get(HEADER_FIRSTNAME) or 'john'
-            lastname = headers.get(HEADER_LASTNAME) or 'doe'
-            userdict = {'email': email,
-                        'name': username,
-                        'fullname': firstname + ' ' + lastname,
-                        'password': '12345678'}
-
-            # create user if missing
-            try:
-                toolkit.get_converter('user_name_exists')(
-                    username,
-                    {'model': model, 'session': model.Session})
-            except toolkit.Invalid:
-                toolkit.get_action('user_create')(
-                    {'model': model, 'session': model.Session, 'user': None, 'ignore_auth': True},
-                    userdict)
-
-            userdict['id'] = toolkit.get_converter('convert_user_name_or_id_to_id')(
-                username,
-                {'model': model, 'session': model.Session})
-            user_obj = toolkit.get_action('user_show')(
-                {'model': model, 'session': model.Session, 'user': None, 'ignore_auth': True},
-                {'id': userdict['id']})
-
-            # update user if necessary
-            #if user_obj['email_hash'] != emailhash or user_obj['fullname'] != userdict['fullname']:
-            #    toolkit.get_action('user_update')(
-            #        {'model': model, 'session': model.Session, 'user': None, 'ignore_auth': True},
-            #        userdict)
-
-            toolkit.c.user = username
-            psession=model.Session
-            #self.update_orgs(userdict)
-        else:
-            toolkit.c.user = None
-
-    # Update organizations associated to the user
-    def update_orgs(self, userdict):
-        # TODO
-        # 1. get list of orgs for this user using get_action('organization_list_for_user')
-        # 2. check if the current user's org is in the list. If not, create it
-        # 3. for the list - the current user's org, remove the user from the orgs
-        # 4. purge ophan orgs : this will be done by the sync_with_LDAP task
-
-        # update Organization info
-        orgs_list = toolkit.get_action('organization_list_for_user')(
-            {'model': model, 'session': model.Session, 'user': '', 'ignore_auth': True},
-            {'id': userdict['id']})
-        log.debug('user {1} belongs to {0} organizations'.format(len(orgs_list), userdict['name']))
-        for org in orgs_list:
-            log.info('belongs to org {0}'.format(org['display_name']))
-
-        headers = toolkit.request.headers
-        user_org_name = headers.get(HEADER_ORG)
-        # check if organization exists
-        try:
-            org_exists = toolkit.get_validator('group_id_or_name_exists')(
-                user_org_name,
-                {'model': model, 'session': model.Session, 'user': '', 'ignore_auth': True})
-
-            log.debug('organization exists ? {0}'.format(org_exists))
-        except toolkit.Invalid:
-            log.debug('organization exists ? nope')
-            #then create organization
-            #self.create_org(user_org_name, userdict)
-
-
-    #create a new organization
-    def create_org(self,user_org_name, userdict):
-        new_org = toolkit.get_action('organization_create')(
-            {},
-            {'name': user_org_name, 'ldap_allow':True })
-        return new_org
-
-
-    # override auth functions
-    def get_auth_functions(self):
-        return {
-            'user_create': auth_function_disabled,
-            'organization_create': auth_function_disabled,
-            'group_create': auth_function_disabled
-        }
-
-    # IConfigurer
-    def update_config(self, config_):
-        pass
-        #toolkit.add_template_directory(config_, 'templates')
-        # toolkit.add_public_directory(config_, 'public')
-        # toolkit.add_resource('fanstatic', 'georchestra')
+    pass

--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -31,10 +31,11 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IAuthenticator)
     #TODO add IConfigurable implementation as in https://github.com/NaturalHistoryMuseum/ckanext-ldap/blob/master/ckanext/ldap/plugin.py
 
+    prefix = config['ckanext.georchestra.role.prefix']
     ldap_roles_dict = {
-        config['ckanext.georchestra.role.sysadmin']: 'sysadmin',
-        config['ckanext.georchestra.role.orgadmin']: 'admin',
-        config['ckanext.georchestra.role.editor']: 'editor'
+        prefix + config['ckanext.georchestra.role.sysadmin']: 'sysadmin',
+        prefix + config['ckanext.georchestra.role.orgadmin']: 'admin',
+        prefix + config['ckanext.georchestra.role.editor']: 'editor'
     }
 
     # ignore basic auth actions
@@ -70,10 +71,12 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
             roles = headers.get(HEADER_ROLES)
             role = 'member' # default
             if roles:
-                for r in roles.split(","):
+                for r in roles.split(";"):
+                    # roles in headers are comma-separated but somehow end up being semicolon-separated here...
                     if r in self.ldap_roles_dict:
                         role = self.ldap_roles_dict[r]
                         break
+            log.debug('identified user {0} with role {1}'.format(username, role))
             userdict = {
                 'id': username,
                 'email': email,

--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -74,10 +74,10 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
                 {'id': userdict['id']})
 
             # update user if necessary
-            if user_obj['email_hash'] != emailhash or user_obj['fullname'] != userdict['fullname']:
-                toolkit.get_action('user_update')(
-                    {'model': model, 'session': model.Session, 'user': None, 'ignore_auth': True},
-                    userdict)
+            #if user_obj['email_hash'] != emailhash or user_obj['fullname'] != userdict['fullname']:
+            #    toolkit.get_action('user_update')(
+            #        {'model': model, 'session': model.Session, 'user': None, 'ignore_auth': True},
+            #        userdict)
 
             toolkit.c.user = username
             psession=model.Session

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-ldap==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    namespace_packages=['ckanext'],
+    namespace_packages=['ckanext','ckanext.georchestra'],
 
     install_requires=[
       # CKAN extensions should not list dependencies here, but in a separate
@@ -81,10 +81,13 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points='''
         [ckan.plugins]
-        georchestra=ckanext.georchestra.plugin:GeorchestraPlugin
+            georchestra=ckanext.georchestra.plugin:GeorchestraPlugin
+        
+        [paste.paster_command]
+            georchestra=ckanext.georchestra.commands.georchestra_ldap:GeorchestraLDAPCommand
 
         [babel.extractors]
-        ckan = ckan.lib.extract:extract_ckan
+            ckan = ckan.lib.extract:extract_ckan
     ''',
 
     # If you are changing from the default layout of your extension, you may


### PR DESCRIPTION
To test it, 
* clone https://github.com/jeanpommier/docker-ckan/tree/updated_ckanextgeorchestra/ckan/src
* `make docker-dev-start`

* Add LDAP entries to give some privileges to some users: in ldap container, run
```
echo '# CKAN_SYSADMIN, roles, georchestra.org
dn: cn=CKAN_SYSADMIN,ou=roles,dc=georchestra,dc=org
objectClass: top
objectClass: groupOfMembers
cn: CKAN_SYSADMIN
ou: 120
description: This group grants sysadmin access to CKAN
member: uid=testadmin,ou=users,dc=georchestra,dc=org

# CKAN_EDITOR, roles, georchestra.org
dn: cn=CKAN_EDITOR,ou=roles,dc=georchestra,dc=org
objectClass: top
objectClass: groupOfMembers
cn: CKAN_EDITOR
ou: 121
description: This group grants edit rights in CKAN
member: uid=testeditor,ou=users,dc=georchestra,dc=org

# CKAN_ADMIN, roles, georchestra.org
dn: cn=CKAN_ADMIN,ou=roles,dc=georchestra,dc=org
objectClass: top
objectClass: groupOfMembers
cn: CKAN_ADMIN
ou: 122
description: This group grants org admin rights in CKAN
member: uid=testreviewer,ou=users,dc=georchestra,dc=org' > ckan_adds.ldif && \
ldapadd -x -D "cn=admin,dc=georchestra,dc=org" -w secret -H ldap:// -f ckan_adds.ldif
```
* in ckan container, run `paster --plugin=ckanext-georchestra georchestra ldap_sync_all -c  /etc/ckan/production.ini` to update & create organizations
* log in as testuser in the console then visit https://georchestra.mydomain.org/ckan/ You are a user without priviledges belonging to PSC org
* logout and login now as testeditor then visit https://georchestra.mydomain.org/ckan/ You are a user with editor priviledges belonging to C2C org
* logout and login now as testreviewer then visit https://georchestra.mydomain.org/ckan/ You are a user with admin priviledges on CRA org
* logout and login now as testadmin then visit https://georchestra.mydomain.org/ckan/ You are sysadmin and can view all orgs


What's not done already :
* create users' org on login if it doesn't exist
* manage datasets associated to an org that is deleted during the paster command process (for now, probably, deleting an org that has datasets might just fail)
* deactivate some functions like editing user's profile
* document configuration
* testing