### PR TITLE
take into account extra org fields from https://github.com/georchestra/georchestra/pull/2552

### DIFF
--- a/ckanext/georchestra/templates/organization/snippets/organization_item.html
+++ b/ckanext/georchestra/templates/organization/snippets/organization_item.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+{# Add support for base64 encoded image as organization logo #}
+
+{% set logo_url = organization.image_url if organization.image_url.startswith('data:') else organization.image_display_url %}
+
+{% block image %}
+  <img src="{{ logo_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-responsive media-image">
+{% endblock %}

--- a/ckanext/georchestra/templates/snippets/organization.html
+++ b/ckanext/georchestra/templates/snippets/organization.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+{# Add support for base64 encoded image as organization logo #}
+
+{% set logo_url = organization.image_url if organization.image_url.startswith('data:') else organization.image_display_url %}
+{% block image %}
+  <div class="image">
+    <a href="{{ url }}">
+      <img src="{{ logo_url or h.url_for_static('/base/images/placeholder-organization.png') }}" width="200" alt="{{ organization.name }}" />
+    </a>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Supports new LDAP fields:
-  jpegPhoto (base64 encoded image) : used as image for the organization
- labeledURI : web URL to website
the picture is stored as base64 data and displayed directly. This needed a few mods in the templates. There is a PR on ckan to officially support base64 images : https://github.com/ckan/ckan/pull/4788