### PR TITLE
rename "map" to "route" because map a core function

### DIFF
--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -71,14 +71,14 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
 
 
     # IRoutes
-    def before_map(self, map):
+    def before_map(self, routes):
         controller = 'ckanext.georchestra.controller:GeorchestraController'
-        with SubMapper(map, controller=controller) as m:
+        with SubMapper(routes, controller=controller) as m:
             m.connect('ckanext_georchestra_logout',
                       '/georchestra_logout', action='georchestra_logout'),
             m.connect('ckanext_georchestra_login',
                       '/georchestra_login', action='georchestra_login')
-        return map
+        return routes
 
     # ignore basic auth actions
     def login(self):


### PR DESCRIPTION
map is a core function in python, it does not clash for the moment, but
it could