### PR TITLE
[fix] support capitals in orphan_orgs' name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Additionally, the plugin provides the following optional parameters:
 - `ckanext.georchestra.role.orgadmin`: CKAN admin role name as defined in geOrchestra's console (default: `CKAN_ADMIN`)
 - `ckanext.georchestra.role.editor`: CKAN editor role name as defined in geOrchestra's console (default: `CKAN_EDITOR`)
 - `ckanext.geOrchestra.external_users`: used to keep root sysadmin user out of the sync process (we don't want it removed...) (default: `ckan`)
-- `ckanext.georchestra.orphans.users.purge`: If True, ckan users that don't belong to the LDAP base are purged from the database. If False, they are removed from all organizations and added to a orphan_users org (default `False`)
-- `ckanext.georchestra.orphans.users.orgname`: orphan_users organization name (default: ` orphan_users`)
+- `ckanext.georchestra.orphans.users.purge`: If True, ckan users that don't belong to the LDAP base are purged from the database. If False, they are removed from all organizations and added to a orphan_users org (default `False`).
+In production, it is advised to set purge to True so that people removed from the LDAP are properly removed from the CKAN database too.
+- `ckanext.georchestra.orphans.users.orgname`: orphan_users organization name (default: `orphan_users`)
 - `ckanext.georchestra.organization.ghosts.prefix`: Prefix added to the title of organizations that should be deleted but still contain datasets: they are referred as ghost, pending cleaning , for further deletion (default `[GHOST]`)
 
 

--- a/ckanext/georchestra/utils/ldap_utils.py
+++ b/ckanext/georchestra/utils/ldap_utils.py
@@ -123,6 +123,7 @@ class GeorchestraLdap():
         result = []
         pages = 0
         processed_items=[]
+        response = None
         # Do searches until we run out of "pages" to get from
         # the LDAP server.
         while True:
@@ -136,6 +137,7 @@ class GeorchestraLdap():
                                       serverctrls=[page_control])
             except ldap.LDAPError as e:
                 log.error('LDAP search failed: %s' % e)
+                return None
 
             # Pull the results from the search request
             try:


### PR DESCRIPTION
Name 'Particulier' should now be supported for oprhan_org name. But I would rather advise, in production, to set ckanext.georchestra.orphans.users.purge=True (and the oprhan_org name will not mater anymore in that case)
Else, we'll have trailing deleted users in the orpan_org org, and this might be confusing. Users removed from LDAP should actually be removed. I checked, there seems to be no consequences on the dataset they may have created in CKAN