### PR TITLE
[fix] rename all trailing occurrences of README.rst to .md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 include LICENSE
 include requirements.txt
 recursive-include ckanext/georchestra *.html *.json *.js *.less *.css *.mo

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Should fix CI error
```
Step 21/39 : RUN pip install 'file:///src/ckanext-georchestra#egg=ckanext-georchestra'
 ---> Running in 66dc366f237a
Processing /src/ckanext-georchestra
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-jvGq5Z/ckanext-georchestra/setup.py", line 10, in <module>
        with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
      File "/usr/lib/python2.7/codecs.py", line 896, in open
        file = __builtin__.open(filename, mode, buffering)
    IOError: [Errno 2] No such file or directory: '/tmp/pip-build-jvGq5Z/ckanext-georchestra/README.rst'
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-jvGq5Z/ckanext-georchestra/
```