### PR TITLE
Implement a force_update option for sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ Full Synchronization is done running paster command
 
 This should be run on a regular basis, like in a cron task.
 
+## Criteria of update
+
+**Organizations** in CKAN provide a `organization_revision_list` action, that can give the time of last update. This is 
+compared with the  `modifyTimestamp` (internal) attribute from the LDAP database to decide if the organization needs to 
+be updated. 
+
+**Users** do not provide such a service. In consequence, we compare a 
+[list of fields](https://github.com/georchestra/ckanext-georchestra/blob/master/ckanext/georchestra/utils/users.py#L23)
+to determine if the entry needs updating.
+
+Normally, this should be enough. But in case it is not, you can force the update on every entry:
+- by setting `ckanext.georchestra.sync.force_update` to `True` in the configuration `.ini` file
+- by setting a `CKAN_LDAP_SYNC_FORCE=True` environment variable
+- by adding `force_update` in the paster command, just after `ldap_sync_all`
+
+Each one of those options overrides the previous ones.
+
 
 ## Requirements
 
@@ -57,6 +74,7 @@ Some configuration options can be set using environment variables. The list is g
 ```
 CONFIG_FROM_ENV_VARS = {
     'ckanext.georchestra.ldap.uri': 'CKAN_LDAP_URL',
+    'ckanext.georchestra.sync.force_update': 'CKAN_LDAP_SYNC_FORCE',
 }
 ```
 Variables set using environment variables override file-based ones.

--- a/ckanext/georchestra/commands/georchestra_ldap.py
+++ b/ckanext/georchestra/commands/georchestra_ldap.py
@@ -13,7 +13,6 @@ from ckanext.georchestra.utils import users as user_utils
 
 log = logging.getLogger()
 
-
 class GeorchestraLDAPCommand(CkanCommand):
     """
     Paster function to synchronize the users/organizations with the LDAP directory
@@ -43,6 +42,9 @@ class GeorchestraLDAPCommand(CkanCommand):
         cmd = self.args[0]
 
         if cmd == 'ldap_sync_all':
+            if 'force_update' in self.args:
+                # Override configuration param
+                config['ckanext.georchestra.sync.force_update'] = True
             self.ldap_sync_all()
         elif cmd == 'purge_org': # needs you to provide the org id
             org_utils.delete(self.context, self.args[1])

--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -24,6 +24,7 @@ HEADER_TEL = "sec-tel"
 
 CONFIG_FROM_ENV_VARS = {
     'ckanext.georchestra.ldap.uri': 'CKAN_LDAP_URL',
+    'ckanext.georchestra.sync.force_update': 'CKAN_LDAP_SYNC_FORCE',
 }
 
 log = logging.getLogger(__name__)
@@ -195,6 +196,7 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
             'ckanext.georchestra.orphans.users.purge': {'default': False, 'parse': toolkit.asbool},
             'ckanext.georchestra.orphans.users.orgname': {'default': 'orphan_users'},
             'ckanext.georchestra.organization.ghosts.prefix': {'default': '[GHOST] '},
+            'ckanext.georchestra.sync.force_update': {'default': False, 'parse': toolkit.asbool},
         }
         errors = []
         for i in schema:

--- a/ckanext/georchestra/utils/organizations.py
+++ b/ckanext/georchestra/utils/organizations.py
@@ -9,8 +9,9 @@ from ckan import model
 log = logging.getLogger()
 
 
-def update_or_create(context, org, force_update=False):
+def update_or_create(context, org):
     try:
+        force_update = toolkit.config.get('ckanext.georchestra.sync.force_update', False)
         ckanorg = toolkit.get_action('organization_show')(context.copy(), {'id': org['id'], 'include_extras': True})
         revisions = toolkit.get_action('organization_revision_list')(context.copy(), {'id': org['id']})
         # If no error, also means the org exists
@@ -26,7 +27,7 @@ def update_or_create(context, org, force_update=False):
         #  - force_update : mostly for testing purpose
         if (org['update_ts'] > last_revision) or (len(ckanorg['title']) == 0) or force_update:
             # then we update it
-            log.debug("updating organization {0}".format(org['name']))
+            log.debug("{1}updating organization {0}".format(org['name'], 'force-' if force_update else ''))
             # We need this to update the logo:
             if 'image_url' in org:
                 org['clear_upload'] = True

--- a/ckanext/georchestra/utils/organizations.py
+++ b/ckanext/georchestra/utils/organizations.py
@@ -28,7 +28,7 @@ def update_or_create(context, org, force_update=False):
             # then we update it
             log.debug("updating organization {0}".format(org['name']))
             # We need this to update the logo:
-            if org.get('image_url'):
+            if 'image_url' in org:
                 org['clear_upload'] = True
             toolkit.get_action('organization_patch')(context.copy(), org)
         else:

--- a/ckanext/georchestra/utils/users.py
+++ b/ckanext/georchestra/utils/users.py
@@ -13,11 +13,12 @@ import ckanext.georchestra.utils.ldap_utils as ldap_utils
 log = logging.getLogger()
 
 
-def update_or_create(context, user, force_update=False):
+def update_or_create(context, user):
     # note : ckan does not provide revisions for user profile. This means we can't check timestamps.
     # so we use the user's profile, and check for differences on synced attributes
     # ckan_user = toolkit.get_action('user_show')(context, {'id':user['id']})
     try:
+        force_update = toolkit.config.get('ckanext.georchestra.sync.force_update', False)
         # Update user profile
         ckan_user = toolkit.get_action('user_show')(context.copy(), {'id': user['id']})
         check_fields = ['name', 'email', 'about', 'fullname', 'display_name', 'sysadmin', 'state']
@@ -25,7 +26,7 @@ def update_or_create(context, user, force_update=False):
         needs_update = reduce(lambda x, y: x or y, checks)
         if needs_updating(check_fields, ckan_user, user) or force_update:
             toolkit.get_action('user_update')(context.copy(), user)
-            log.debug("updated user {0}".format(user['name']))
+            log.debug("{1}updated user {0}".format(user['name'], 'force-' if force_update else ''))
         else:
             log.debug("user {0} is up-to-date".format(user['name']))
 


### PR DESCRIPTION
Sometimes, it seems CKAN misses some information it should patch, particularly the image possibly attached to an organization. You might then need, in such cases, to force an update on every entries. 