### PR TITLE
Fix roles resolution

### DIFF
--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -108,7 +108,6 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
         headers = toolkit.request.headers
         # Headers are not case-sensitive, meaning we can get uppercased of camel-cased headers => we lower-case them
         headers = {k.lower():v for k,v in headers.items()}
-        log.debug("headers {}".format(', '.join(map(str, headers))))
         username = headers.get(HEADER_USERNAME)
         if not username:
             toolkit.c.user = None

--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -119,15 +119,18 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
         lastname = headers.get(HEADER_LASTNAME) or u'doe'
         roles = headers.get(HEADER_ROLES)
         org = ldap_utils.sanitize(headers.get(HEADER_ORG))
+
+        # define role for user (default is unprivileged 'member'
         role = u'member' # default
         prefix = config['ckanext.georchestra.role.prefix']
-        ldap_roles_dict = ldap_utils.get_ldap_roles_list(prefix)
+        ldap_roles_dict = ldap_utils.get_ldap_roles_as_ordereddict(prefix)
         if roles:
-            for r in roles.split(";"):
-                if r in ldap_roles_dict:
-                    role = ldap_roles_dict[r]
+            for k, v in ldap_roles_dict.iteritems():
+                if k in roles.split(";"):
+                    role = v
                     break
         log.debug('identified user {0} with role {1}'.format(username, role))
+
         userdict = {
             'id': username,
             'email': email,


### PR DESCRIPTION
Fix CKAN roles resolution order
    
    It did not consider the possibility that we give several CKAN roles to a given
    user. It picked the first identified role, and the order was, in fact,
    random-ish.
    If a user was given, for instance, CKAN_EDITOR and CKAN_ADMIN, the retained role
    might have been `editor`
    This fix improved the matching and will give the highest role given to the user.