### PR TITLE
 [fix] Users without CKAN-related role in sec-headers should get 'member' role

### DIFF
--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -28,6 +28,7 @@ go_headers = {
 CONFIG_FROM_ENV_VARS = {
     'ckanext.georchestra.ldap.uri': 'CKAN_LDAP_URL',
     'ckanext.georchestra.sync.force_update': 'CKAN_LDAP_SYNC_FORCE',
+    'ckanext.georchestra.orphans.users.purge': 'CKAN_LDAP_SYNC_ORPHANS_PURGE',
 }
 
 log = logging.getLogger(__name__)

--- a/ckanext/georchestra/plugin.py
+++ b/ckanext/georchestra/plugin.py
@@ -80,6 +80,11 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
         """Implementation of IAuthenticator.abort"""
         return status_code, detail, headers, comment
 
+    def get_superuser_context(self):
+        user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
+        context = {'user': user['name']}
+        return context
+
     def identify(self):
         """Implementation of IAuthenticator.identify
         Used to determine the currently logged in user
@@ -108,13 +113,15 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
                 # User identified, we're done here
                 return
 
+            log.debug('Checking user {}, role {}, org {}'.format(userobj.id, userdict['role'], userdict['org_id']))
             # For non-sysadmins, we also want to check he is still member of the org declared in the headers
             if self.organization_check_for_user(userobj.id, userdict['org_id'], userdict['role']):
                 # no change with org, we're done here
                 return
             else:
-                organizations_utils.organization_set_member_or_create(self.context.copy(),
-                                                                      userobj.id, userdict['org_id'], userdict['role'])
+                log.debug('Needs to update user {}: set as {} role on org {}'.format(userobj.id, userdict['role'], userdict['org_id']))
+                organizations_utils.organization_set_member_or_create(self.get_superuser_context().copy(),
+                                                                     userobj.id, userdict['org_id'], userdict['role'])
 
         # (else:)
         log.debug('User {0} does not have an account yet in ckan. Creating the user'.format(username))
@@ -124,7 +131,7 @@ class GeorchestraPlugin(plugins.SingletonPlugin):
         user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
         context = {'user': user['name']}
         ckan_user = user_utils.create(context, userdict)
-        if not userobj:
+        if not ckan_user:
             # There was an error. Log the info, and be anonymous
             log.warning('There was an error creating the user. Logging you as anonymous.')
             toolkit.c.user = None

--- a/ckanext/georchestra/tests/test_unittests_georchestra.py
+++ b/ckanext/georchestra/tests/test_unittests_georchestra.py
@@ -70,6 +70,33 @@ class TestGeorchestraHeaders(unittest.TestCase):
         }
         self.assertDictEqual(user_dict, expected_dict)
 
+    def test_no_ckan_role_in_sec_headers_end_as_member_role(self):
+        '''Headers should be unicode
+        '''
+        sec_headers = {
+            'sec-roles': u'ROLE_GT_CHEMINS;ROLE_GN_ADMIN;ROLE_EXTRACTORAPP;ROLE_GN_EDITOR',
+            'sec-firstname': u'François',
+            'sec-email': u'fpomfont@pomfont.fr',
+            'sec-tel': u'03 74 00 00 00',
+            'sec-username': u'fpomfont',
+            'sec-lastname': u'Pomfont',
+            'sec-org': u'region_hdf',
+        }
+        from ckanext.georchestra.plugin import _user_dict_from_sec_headers
+        user_dict = _user_dict_from_sec_headers(sec_headers)
+        expected_dict = {
+            'sysadmin': False,
+            'state': u'active',
+            'role': u'member',
+            'name': u'fpomfont',
+            'fullname': u'François Pomfont',
+            'password': u'12345678',
+            'org_id': u'region_hdf',
+            'id': u'fpomfont',
+            'email': u'fpomfont@pomfont.fr'
+        }
+        self.assertDictEqual(user_dict, expected_dict)
+
     def test_sec_headers_latin1_produce_valid_userdict(self):
         '''It seems sometimes Pylons might return headers as latin1-encoded byte-strings
         '''

--- a/ckanext/georchestra/utils/ldap_utils.py
+++ b/ckanext/georchestra/utils/ldap_utils.py
@@ -31,7 +31,7 @@ def get_ldap_roles_as_ordereddict(prefix=''):
 
 def get_ckan_role_from_security_proxy_roles(sec_roles):
     # define role for user (default is unprivileged 'member')
-    role = u'member'  # default
+    default_role = u'member'  # default
     # security-proxy adds a prefix in front of the LDAP roles
     prefix = config['ckanext.georchestra.role.prefix']
     ldap_roles_dict = get_ldap_roles_as_ordereddict(prefix)
@@ -39,6 +39,7 @@ def get_ckan_role_from_security_proxy_roles(sec_roles):
         for key, role in ldap_roles_dict.iteritems():
             if key in sec_roles.split(";"):
                 return role
+    return default_role
 
 
 class GeorchestraLdap():

--- a/ckanext/georchestra/utils/organizations.py
+++ b/ckanext/georchestra/utils/organizations.py
@@ -96,7 +96,7 @@ def delete_all_orgs(context, delete_active=False):
 def organization_set_member_or_create(context, user_id, org_id, role):
     """
     Set user as member of the organization, with the given role.
-    If the organization doesn't exist, create the organization, setting only it's ID. The remaining information will
+    If the organization doesn't exist, create the organization, setting only its ID. The remaining information will
     be completed on next full sync (paster command)
     :param context:
     :param user_id:
@@ -110,7 +110,7 @@ def organization_set_member_or_create(context, user_id, org_id, role):
         log.debug("added user to {0}".format(org_id))
 
     except toolkit.ValidationError:
-        # Means it doesn't exist yet => we create it
+        # Means the org doesn't exist yet => we create it
         log.debug("Creating organization {0}".format(org_id))
         toolkit.get_action('organization_create')(context.copy(), {'name': org_id})
         log.debug("adding user to {0}".format(org_id))


### PR DESCRIPTION
They were given 'None' role, which was not valid.. 
Also fixing a pylons context related issue